### PR TITLE
Cleaning up READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,34 @@
 enermaps2 is a rewrite of the hotmaps poc based on the previous experience.
 
-# Run a local copy
-run a 
+# Development
+First you need to have docker installed on your machine.
+
+Then run
 
 ```
 docker-compose up --build
 ```
+This will start the frontend, the api and the database
+
 You can then access:
 
 * the frontend on http://127.0.0.1:7000
 * the api on http://127.0.0.1:7000/api
+* the database on 127.0.0.1:5433
 
-# frontend
+The initial database schema will be created following the step in ![](db/README.md).
 
-app
-
-then accessed trough http://127.0.0.1:8000
-
-# api
-
-You can also run the debug server with 
+For updating a service, you will need to run:
 
 ```
-python api/main.py
+docker-compose up --build -d $service
 ```
-and access it trough http://127.0.0.1:5000
 
-# db
+where service can be one of frontend, api or db.
 
-Database initialisation schema is ran when no previous data schema is found upon starting the db image.
+You can also rebuild the set of all service, and docker will only rebuilt the 
+changed images with the following command:
 
-You can access the database trough 127.0.0.1:5433
+```
+docker-compose up --build -d
+```

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND="nointeractive" TZ="Europe/Zurich"
 RUN apt update && apt install --yes python3-mapnik python3-pip python3-gunicorn gunicorn python3-gdal

--- a/api/README.md
+++ b/api/README.md
@@ -1,21 +1,29 @@
-Enermaps api
+Enermaps HTTP api.
 
 This directory host the api for the enermaps project.
 
-# testing 
-Running all test in the repository can be done via 
+# Running locally
+
+For running the api locally, the current recommended method 
+is to use docker-compose (see the README at the root of the directory).
+
+You can still run the api locally for developpement purpose. You will need
+
+* python 3.6+
+* pip
+* mapnik version above 3.0
+
+You can optionally create a virtual environment prior to running the install commands for installing the environment.
+
+Then proceed to install the requirement with:
 
 ```
-python test.py
+pip install -r requirements.txt
 ```
 
-Those test are also ran as part of the docker build process.
+You should then be able to run main.py for running the webserver locally or test.py for running all tests.
 
-# running
-
-you can either run under a wsgi with `wsgi.py`
-or run locally for debug purpose with `main.py`
-
-# linting
+# Linting
 
 We run black on version 20.8b1.
+We advise you to run isort to take care of the order of dependencies.

--- a/api/README.md
+++ b/api/README.md
@@ -12,6 +12,7 @@ python test.py
 Those test are also ran as part of the docker build process.
 
 # running
+
 you can either run under a wsgi with `wsgi.py`
 or run locally for debug purpose with `main.py`
 

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,4 +1,4 @@
-flask-restx=0.2.0
+flask-restx==0.2.0
 lxml==4.5.2
-GDAL==
-Pillow==
+GDAL==3.0.4
+Pillow==7.2.0

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,4 +1,4 @@
-flask-restx
-lxml
-GDAL
-Pillow
+flask-restx=0.2.0
+lxml==4.5.2
+GDAL==
+Pillow==

--- a/db/README.md
+++ b/db/README.md
@@ -1,0 +1,4 @@
+database for the enermaps2 project.
+
+We use postgresql with postgis. The initial database schema 
+can be found in db/add_dataset_db.sql


### PR DESCRIPTION
Clarifying the READMEs for running the dev version.
In the api README, specify the requirement for running the api locally without docker.
In the db README, specify where to find the initial schema.