### PR TITLE
Use SIGINT as signal to `docker-compose stop db`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
     restart: always
     environment:
       POSTGRES_PASSWORD: example
+    stop_signal: SIGINT                 # Fast Shutdown mode
     volumes:
       - db-data:/var/lib/postgresql/data
     env_file:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,9 @@ services:
     restart: always
     environment:
       POSTGRES_PASSWORD: example
-    stop_signal: SIGINT                 # Fast Shutdown mode
+    # Fast Shutdown mode
+    # see https://github.com/docker-library/postgres/issues/714
+    stop_signal: SIGINT
     volumes:
       - db-data:/var/lib/postgresql/data
     env_file:


### PR DESCRIPTION
make sigint the default signal for stopping psql (see https://github.com/docker-library/postgres/issues/714), this makes the kill abort connection (idle ones included) and should make docker stop db more resilient.