### PR TITLE
make the shapefile upload atomic

### DIFF
--- a/api/app/endpoints/geofile.py
+++ b/api/app/endpoints/geofile.py
@@ -27,12 +27,15 @@ class GeoFiles(Resource):
         """Add a geofile, currently only raster is supported in a geotiff format.
 
         Later we plan on supporting
-        * csv linking a NUTS to a value and shapefile.
-        * shapefiles
+        * csv: linking a NUTS to a value and shapefile.
         """
         args = upload_parser.parse_args()
         uploaded_file = args["file"]  # This is FileStorage instance
-        layer = geofile.create(uploaded_file)
+        # TODO this should be in the error handler instead
+        try:
+            layer = geofile.create(uploaded_file)
+        except geofile.SaveException as e:
+            abort(400, str(e))
         if not layer.projection:
             layer.delete()
             abort(400, "The uploaded file didn't contain a projection")

--- a/api/app/endpoints/test_geofile.py
+++ b/api/app/endpoints/test_geofile.py
@@ -20,6 +20,14 @@ class VectorGeofileTest(BaseApiTest):
         json_content = json.loads(response.data)
         self.assertIn(testfile, json_content["files"])
 
+    def testUploadBadZip(self):
+        testfile = "hotmaps-cdd_curr_adapted.tif"
+        test_data, _ = self.get_testformdata(testfile, testfile_name="test.zip")
+        response = self.client.post(
+            "api/geofile/", data=test_data, content_type="multipart/form-data"
+        )
+        self.assertEqual(response.status, "400 BAD REQUEST", response.data)
+
 
 class TifGeofileTest(BaseApiTest):
     def testFileEscapePost(self):


### PR DESCRIPTION
Non atomic unzip make that you can end up with a shapefile with no projection. 
Fixes this by renaming the directory after unzipping.