### PR TITLE
Threaded fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ changed images with the following command:
 ```
 docker-compose up --build -d
 ```
+
+Some service will initialize and create their initial state:
+
+* the api will fetch an initial dataset
+* the db will create its initial schema
+
 ## Cleanup
 
 You can stop the entire stack with

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -19,4 +19,4 @@ COPY . .
 RUN python3 test.py
 
 EXPOSE 80
-CMD ["gunicorn", "--bind", "0.0.0.0:80", "wsgi:app"]
+CMD ["gunicorn", "--config", "gunicorn.py", "--bind", "0.0.0.0:80", "wsgi:app"]

--- a/api/README.md
+++ b/api/README.md
@@ -26,7 +26,7 @@ You should then be able to run main.py for running the webserver locally or test
 ```
 python $(pwd)/main.py
 ```
-The api will listen http://127.0.0.1:7000
+The api will listen http://127.0.0.1:7000 after a short initialisation period.
 
 # Linting
 

--- a/api/app/__init__.py
+++ b/api/app/__init__.py
@@ -44,12 +44,12 @@ def init_dataset():
         **base_query_params,
         **{
             "typeName": "hotmaps:nuts",
-            "CQL_FILTER": "stat_levl_='{!s}' AND year='2013-01-01'",
         },
     }
+    cql_filter = "stat_levl_='{!s}' AND year='2013-01-01'"
     lau_query = {**base_query_params, **{"typeName": "hotmaps:tbl_lau1_2"}}
     for i in range(4):
-        nuts_query["CQL_FILTER"] = nuts_query["CQL_FILTER"].format(i)
+        nuts_query["CQL_FILTER"] = cql_filter.format(i)
         filename = "nuts{!s}.zip".format(i)
         fetch_dataset(base_url, nuts_query, filename)
 

--- a/api/gunicorn.py
+++ b/api/gunicorn.py
@@ -1,0 +1,21 @@
+"""Configuration file for gunicorn, As we are using init hooks,
+we need to keep this file in python (see
+https://github.com/benoitc/gunicorn/blob/master/examples/example_config.py)
+for an example.
+"""
+import sys
+
+from app import create_app
+
+
+def on_starting(_):
+    """This is a gunicorn hook that is run once upon starting the server.
+    We use this hook to setup the initial data creation, right now those are
+    run upon app creation, so we just create a dummy application to trigger
+    those hooks
+    """
+    print("Running the startup hook ", flush=True)
+    create_app()
+    print("startup hook finished")
+    #  Explicitely flush so that we have the init logs
+    sys.stdout.flush()


### PR DESCRIPTION
Original approach of this bug fix was to avoid gunicorn timing out upon creation of the initial dataset. 

The final proposed approach is to use the gunicorn startup hooks instead and just call the app creation function to trigger the creation of initial state.