### PR TITLE
height and width are ignore in inline mode

### DIFF
--- a/frontend/src/src/components/CMToggle.svelte
+++ b/frontend/src/src/components/CMToggle.svelte
@@ -8,6 +8,7 @@ function toggleCM() {
 #cm_toggle {
   height: 100%;
   width: 100%;
+  display: block;
   cursor: pointer;
 }
 #cm_toggle_container:hover {


### PR DESCRIPTION
so the a tag was actually sized at 0 under some circumstance.