### PR TITLE
Location of data volume from data-integration

### DIFF
--- a/data-integration/Dockerfile
+++ b/data-integration/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update &&\
     apt-get --yes install python3 python3-pip \
     postgresql-client \
     gdal-bin \
+    proj-bin \
     libgdal-dev &&\
     rm -rf /var/cache/apt/archives/
 
@@ -14,8 +15,8 @@ RUN apt-get update &&\
 ENV CPLUS_INCLUDE_PATH=/usr/include/gdal
 ENV C_INCLUDE_PATH=/usr/include/gdal
 
-COPY requirements.txt di/requirements.txt
-WORKDIR di
+COPY requirements.txt /data-integration/requirements.txt
+WORKDIR data-integration
 RUN pip3 install -r requirements.txt
 
 # PROVISIONAL: Installed a forked version of pandas-datapackage-reader
@@ -23,7 +24,8 @@ RUN apt-get --yes install git
 RUN git clone https://github.com/enermaps/pandas-datapackage-reader.git
 RUN cd pandas-datapackage-reader && pip3 install -e .
 
-COPY . .
+COPY *.py /data-integration/
+COPY *.csv /data-integration/
 
 # Provisional command to keep the container alive
 CMD ["sleep", "infinity"]

--- a/data-integration/Dockerfile
+++ b/data-integration/Dockerfile
@@ -7,7 +7,6 @@ RUN apt-get update &&\
     apt-get --yes install python3 python3-pip \
     postgresql-client \
     gdal-bin \
-    proj-bin \
     libgdal-dev &&\
     rm -rf /var/cache/apt/archives/
 

--- a/data-integration/getHotMaps_raster.py
+++ b/data-integration/getHotMaps_raster.py
@@ -11,11 +11,11 @@ import argparse
 import json
 import logging
 import os
+import shutil
 import sys
 
 import frictionless
 import pandas as pd
-
 import utilities
 
 # Constants
@@ -93,7 +93,7 @@ def get(repository: str, dp: frictionless.package.Package, isForced: bool = Fals
             }
             rasters.append(raster)
             # check statistics for each resource
-            if dp != None and "stats" in new_dp["resources"][resource_idx]:
+            if dp is not None and "stats" in new_dp["resources"][resource_idx]:
                 if (
                     dp["resources"][resource_idx]["stats"]
                     != new_dp["resources"][resource_idx]["stats"]
@@ -101,7 +101,7 @@ def get(repository: str, dp: frictionless.package.Package, isForced: bool = Fals
                     isChangedStats = True
     rasters = pd.DataFrame(rasters)
 
-    if dp != None:  # Existing dataset
+    if dp is not None:  # Existing dataset
         # check stats
         isChangedVersion = dp["version"] != new_dp["version"]
         if isChangedStats or isChangedVersion:
@@ -122,7 +122,7 @@ def get(repository: str, dp: frictionless.package.Package, isForced: bool = Fals
     if not os.path.exists(os.path.join("data", str(ds_id))):
         os.mkdir(os.path.join("data", str(ds_id)))
     for i, row in data_enermaps.iterrows():
-        os.rename(row.fid, os.path.join("data", str(ds_id), row.fid))
+        shutil.move(row.fid, os.path.join("data", str(ds_id), row.fid))
 
     return data_enermaps, new_dp
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,7 @@ services:
     build:
       context: ./data-integration
     volumes:
-      - data:/data
+      - data:/data-integration/data
     env_file:
       .env
 


### PR DESCRIPTION
This might help with retrieving the raster files from other docker services.
You can mount the `data` volume in another service and there you should find the raster files that have been integrated. The path will be: `data/{ds_id}/{fid}` where `fid` is the name of the GeoTiff file.