### PR TITLE
[Calculation Modules] tasks have now a proper routing via celery and the broker

### DIFF
--- a/api/app/common/test.py
+++ b/api/app/common/test.py
@@ -148,7 +148,7 @@ DEFAULT_API_URL = "http://127.0.0.1:7000"
 
 @labeledTest("integration")
 class BaseIntegrationTest(unittest.TestCase):
-    def waitForReachability(self, max_retry=10, wait_time=3):
+    def wait_for_reachability(self, max_retry=10, wait_time=3):
         """Wait for the api to be reachable by poking its healthz endpoint"""
         retry = 0
         logging.info("Waiting for the api to be reachable")
@@ -157,7 +157,9 @@ class BaseIntegrationTest(unittest.TestCase):
                 resp = self.session.get(self.url + "/healthz")
             except (
                 urllib3.exceptions.MaxRetryError,
+                urllib3.exceptions.TimeoutError,
                 requests.exceptions.ConnectionError,
+                requests.exceptions.RequestException,
             ):
                 logging.info(".")
             else:
@@ -171,4 +173,4 @@ class BaseIntegrationTest(unittest.TestCase):
         self.api_url = self.url + "/api"
         self.session = requests.Session()
         super().__init__(*args, **kwargs)
-        self.waitForReachability()
+        self.wait_for_reachability()

--- a/api/app/common/test.py
+++ b/api/app/common/test.py
@@ -148,7 +148,7 @@ DEFAULT_API_URL = "http://127.0.0.1:7000"
 
 @labeledTest("integration")
 class BaseIntegrationTest(unittest.TestCase):
-    def wait_for_reachability(self, max_retry=10, wait_time=3):
+    def wait_for_reachability(self, max_retry=20, wait_time=3):
         """Wait for the api to be reachable by poking its healthz endpoint"""
         retry = 0
         logging.info("Waiting for the api to be reachable")
@@ -164,13 +164,15 @@ class BaseIntegrationTest(unittest.TestCase):
                 logging.info(".")
             else:
                 if resp.ok:
-                    return
+                    return True
             retry += 1
             time.sleep(wait_time)
+        return False
 
     def setUp(self, *args, **kwargs):
         self.url = os.environ.get("API_URL", DEFAULT_API_URL)
         self.api_url = self.url + "/api"
         self.session = requests.Session()
         super().__init__(*args, **kwargs)
-        self.wait_for_reachability()
+        if not self.wait_for_reachability():
+            logging.error("API is not reachable after max retries")

--- a/api/app/models/calculation_module.py
+++ b/api/app/models/calculation_module.py
@@ -59,6 +59,7 @@ class CalculationModule:
 
     def __init__(self, cm_id, **kwargs):
         self.app = get_celery_app()
+        self.queue = kwargs.get("queue", cm_id)
         self.cm_id = cm_id
         self.name = kwargs.get("name", cm_id)
         self.pretty_name = kwargs.get("pretty_name", self.name)
@@ -73,7 +74,8 @@ class CalculationModule:
         this task id serves as a reference for getting the status of the task
         (failure, running or done) and its results.
         """
-        return self.app.send_task(self.cm_id, args, kwargs)
+        # Send to proper queue
+        return self.app.send_task(self.cm_id, args, kwargs, queue=self.queue)
 
 
 def list_cms() -> Dict[Text, CalculationModule]:

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,4 +1,4 @@
-flask-restx==0.2.0
+flask-restx==0.4.0
 lxml==4.6.3
 GDAL==3.0.4
 Pillow==8.1.1

--- a/cm/example_empty/worker.py
+++ b/cm/example_empty/worker.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
-import BaseCM.cm_base as cm_base
+
+from BaseCM import cm_base as cm_base
 from BaseCM.cm_output import validate
 
-app = cm_base.get_default_app()
+app = cm_base.get_default_app("empty")
 schema_path = cm_base.get_default_schema_path()
 
 

--- a/cm/example_multiply/worker.py
+++ b/cm/example_multiply/worker.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
-import BaseCM.cm_base as cm_base
-import BaseCM.cm_input as cm_input
+
+from BaseCM import cm_base as cm_base
+from BaseCM import cm_input as cm_input
 
 from multiply_raster import rasterstats
 
-app = cm_base.get_default_app()
+app = cm_base.get_default_app("multiply")
 schema_path = cm_base.get_default_schema_path()
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,8 @@ services:
     ports:
       - "127.0.0.1:9000:80"
     restart: always
+    depends_on:
+      - "db"
     environment:
       UPLOAD_DIR: /upload-dir
     volumes:


### PR DESCRIPTION
### Summary

This PR targets the problem related to how `celery` and the `broker` handle different tasks which are not recognized (registered) by a worker.

A proper routing solution is proposed here where each `task` has a `default queue` on a specific worker.
This certifies that a CM will only be launched on a certain queue and thus avoid the unregistered issue encountered.

### Logs/Screenshots showing the fix

Caculation modules are processed properly:

![Screenshot from 2021-05-19 16-04-31](https://user-images.githubusercontent.com/2482166/118835580-6ce4ce80-b8c3-11eb-8276-0171a024bf0a.png)

The broker handles the various tasks execution without issues following the proper routing:

![Screenshot from 2021-05-19 16-05-12](https://user-images.githubusercontent.com/2482166/118835686-838b2580-b8c3-11eb-9780-1f910b980d9b.png)

Routing keys are enabled for each queues for the mapping task-queue:

![Screenshot from 2021-05-19 16-05-36](https://user-images.githubusercontent.com/2482166/118835802-9b62a980-b8c3-11eb-8699-21d4652abbe1.png)
![Screenshot from 2021-05-19 16-06-01](https://user-images.githubusercontent.com/2482166/118835809-9c93d680-b8c3-11eb-9e01-063084e96ac5.png)

### Relevant issue(s) fixed

Fixes #219 

Credits: Thanks to @gcmalloc for the precious help (code/discussion/documentation/design explanation) in the resolution of the problem and to @melhk for helping in the debug of the problem!