### PR TITLE
create empty .env-local file

### DIFF
--- a/.github/workflows/pr_to_master.yml
+++ b/.github/workflows/pr_to_master.yml
@@ -70,5 +70,7 @@ jobs:
     runs-on: 'ubuntu-18.04'
     steps:
       - uses: actions/checkout@v2
+      - name: Create an empty env file for variables that should be kept only locally (e.g. secret keys)
+        run: touch .env-local
       - name: Run docker-compose stack
         run: docker-compose build --parallel


### PR DESCRIPTION
This is a workaround to have a local env file (not tracked by git) and be able to run CI in GitHub.
Inspired by this: https://github.com/docker/compose/pull/3955#issuecomment-847646545