### PR TITLE
Add metadata for categorical raster files

### DIFF
--- a/data-integration/getESM-EUDEM.py
+++ b/data-integration/getESM-EUDEM.py
@@ -34,8 +34,9 @@ RECORD_METADATA = {
     "variable": {21: "Elevation", 35: "Land use"},
     "unit": {21: "m", 35: ""},
     "layer": {
-        21: {},
+        21: {"type": "numerical"},
         35: {
+            "type": "categorical",
             "classes": {
                 1: "Water",  # water
                 2: "Railways",  # railways
@@ -143,7 +144,10 @@ def addRecordMetadata(data: pd.DataFrame, metadata: dict):
     for ds_id in data["ds_id"].unique():
         for column in metadata.keys():
             if column not in data.columns:
-                data[column] = "{}"
+                if column == "layer":
+                    data.loc[data["ds_id"] == ds_id, column] = ""
+                else:
+                    data.loc[data["ds_id"] == ds_id, column] = '{"type": "numerical"}'
             if isinstance(metadata[column][ds_id], dict):
                 data.loc[data["ds_id"] == ds_id, column] = json.dumps(
                     metadata[column][ds_id]

--- a/data-integration/getHotMaps_raster.py
+++ b/data-integration/getHotMaps_raster.py
@@ -27,7 +27,8 @@ DB_URL = utilities.DB_URL
 
 LAYER_METADATA = {
     "Climate zones": {
-        "classes": {0: "warmer climate", 1: "average climate", 2: "colder climate"}
+        "type": "numerical",
+        "classes": {0: "warmer climate", 1: "average climate", 2: "colder climate"},
     }
 }
 
@@ -124,7 +125,7 @@ def get(repository: str, dp: frictionless.package.Package, isForced: bool = Fals
 def addLayerMetadata(data: pd.DataFrame, layer_metadata: dict):
     """Add categorical raster layer metadata."""
     if "layer" not in data.columns:
-        data["layer"] = "{}"
+        data["layer"] = '{"type": "numerical"}'
     for variable in layer_metadata.keys():
         data.loc[data["variable"] == variable, "layer"] = json.dumps(
             layer_metadata[variable]

--- a/db/init/add_dataset_db.sql
+++ b/db/init/add_dataset_db.sql
@@ -43,20 +43,21 @@ CREATE TABLE public.data
     fid varchar(200),
     dt double precision,
     z double precision,
-    isRaster boolean
+    isRaster boolean,
+    layer jsonb default'{"type": "numerical"}'::jsonb
 );
 
 
 ALTER TABLE spatial
     ADD CONSTRAINT fk_ds_id
-    FOREIGN KEY(ds_id) 
+    FOREIGN KEY(ds_id)
     REFERENCES datasets(ds_id)
     ON DELETE CASCADE
 ;
 
 ALTER TABLE data
     ADD CONSTRAINT fk_ds_id
-    FOREIGN KEY(ds_id) 
+    FOREIGN KEY(ds_id)
     REFERENCES datasets(ds_id)
     ON DELETE CASCADE
 ;


### PR DESCRIPTION
An additional field is added to the database. Datasets are by default numerical, while information about the classes is added for categorical rasters.
In some cases, a specific color is also suggested per each class. If the `colors` dict is absent, the default color scale should be used.