### PR TITLE
Utilities to run cron jobs

### DIFF
--- a/cron/.enermaps
+++ b/cron/.enermaps
@@ -1,0 +1,2 @@
+PATH=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin
+ENERMAPS_ROOT=/path/to/enermaps

--- a/cron/README.MD
+++ b/cron/README.MD
@@ -1,0 +1,18 @@
+# Utility to schedule jobs
+
+These utilities are used to run periodical routines on the host machine.
+We use Unix `cron` on the host machine, hence not directly in Docker, to run the Docker containers.
+
+Here are the jobs currently implemented:
+
+- `data-integration.sh`contains the data-integration pipelines that have to be run twice per year. Biannual jobs are run *at 02:00 on day-of-month 1 in March and September*.
+
+
+## Usage
+
+- Copy the `.enermaps` to your HOME directory `cp .enermaps ~/.enermaps`.
+
+- Edit the `~/.enermaps` file to set the ENERMAPS_ROOT variable to the path to the EnerMaps root directory
+
+- Append to your user crontab the content of the `crontab.txt` file.
+Use for example `EDITOR=nano crontab -e` to open your user crontab in `nano`.

--- a/cron/crontab.txt
+++ b/cron/crontab.txt
@@ -1,0 +1,6 @@
+SHELL=/bin/bash
+
+# Biannual pipelines at 02:00 on day-of-month 1 in March and September
+0 2 1 MAR,SEP * source ~/.enermaps; cd $ENERMAPS_ROOT/cron && ./data-integration.sh  >> enermaps_di.log 2>&1
+
+# An empty line is required at the end of this file for a valid cron file.

--- a/cron/data-integration.sh
+++ b/cron/data-integration.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Load variables
+export $(grep -v '^#' ~/.enermaps | xargs)
+
+# Run pipelines
+# 1
+echo $(date -u) && docker-compose -f $ENERMAPS_ROOT/docker-compose-db.yml run data-integration getPVGIS.py
+# 2
+echo $(date -u) && docker-compose -f $ENERMAPS_ROOT/docker-compose-db.yml run data-integration getJRC_GEOPP_DB_csv.py
+# 3
+echo $(date -u) && docker-compose -f $ENERMAPS_ROOT/docker-compose-db.yml run data-integration getJRC_hydro-power.py
+# 4
+echo $(date -u) && docker-compose -f $ENERMAPS_ROOT/docker-compose-db.yml run data-integration getJRC_PPDB-OPEN.py
+# 5
+echo $(date -u) && docker-compose -f $ENERMAPS_ROOT/docker-compose-db.yml run data-integration getEEA.py
+# 6, 9, 22, 42, 47, 48, 49, 50
+echo $(date -u) && docker-compose -f $ENERMAPS_ROOT/docker-compose-db.yml run data-integration getEurostat.py
+# 7
+echo $(date -u) && docker-compose -f $ENERMAPS_ROOT/docker-compose-db.yml run data-integration getElectricity.py
+# 8
+echo $(date -u) && docker-compose -f $ENERMAPS_ROOT/docker-compose-db.yml run data-integration getPopulation.py
+# 11
+echo $(date -u) && docker-compose -f $ENERMAPS_ROOT/docker-compose-db.yml run data-integration getSETIS.py
+# 14
+echo $(date -u) && docker-compose -f $ENERMAPS_ROOT/docker-compose-db.yml run data-integration getPANGAEA.py
+# 15, 20
+echo $(date -u) && docker-compose -f $ENERMAPS_ROOT/docker-compose-db.yml run data-integration getEra5.py
+# 16, 17 will not be updated
+# echo $(date -u) && docker-compose -f $ENERMAPS_ROOT/docker-compose-db.yml run data-integration getEMHIRES.py
+# 18
+echo $(date -u) && docker-compose -f $ENERMAPS_ROOT/docker-compose-db.yml run data-integration getEnergydata.py
+# 19
+echo $(date -u) && docker-compose -f $ENERMAPS_ROOT/docker-compose-db.yml run data-integration getEdgar.py
+# 21 will not be updated
+# echo $(date -u) && docker-compose -f $ENERMAPS_ROOT/docker-compose-db.yml run data-integration getESM-EUDEM.py
+# 23 will not be updated
+# echo $(date -u) && docker-compose -f $ENERMAPS_ROOT/docker-compose-db.yml run data-integration getWater.py
+# 24 will not be updated
+# echo $(date -u) && docker-compose -f $ENERMAPS_ROOT/docker-compose-db.yml run data-integration getSolarAtlas.py
+# 25, 31, 43, 45
+echo $(date -u) && docker-compose -f $ENERMAPS_ROOT/docker-compose-db.yml run data-integration getHotMaps_raster.py
+# 27 will not be updated
+# echo $(date -u) && docker-compose -f $ENERMAPS_ROOT/docker-compose-db.yml run data-integration getS2BIOM.py
+# 28
+echo $(date -u) && docker-compose -f $ENERMAPS_ROOT/docker-compose-db.yml run data-integration getHotMaps_tabular.py
+# 29 will not be updated
+# echo $(date -u) && docker-compose -f $ENERMAPS_ROOT/docker-compose-db.yml run data-integration getSET-Nav.py
+# 30 will not be updated
+# echo $(date -u) && docker-compose -f $ENERMAPS_ROOT/docker-compose-db.yml run data-integration getENER.py
+# 33 will not be updated
+# echo $(date -u) && docker-compose -f $ENERMAPS_ROOT/docker-compose-db.yml run data-integration getBuildingHeight.py
+# 35 will not be updated
+# echo $(date -u) && docker-compose -f $ENERMAPS_ROOT/docker-compose-db.yml run data-integration getESM-EUDEM.py
+# 46
+echo $(date -u) && docker-compose -f $ENERMAPS_ROOT/docker-compose-db.yml run data-integration getOECD.py


### PR DESCRIPTION
This is used to run periodical jobs using the docker containers, notably the data-integrationpipelines that are run biannually to update the database content.
Please note that some of the pipelines run by the bash file are not yet included in the `master` branch.