### PR TITLE
Don't fetch datasets in all the threads

### DIFF
--- a/api/app/__init__.py
+++ b/api/app/__init__.py
@@ -22,7 +22,8 @@ def create_app(environment="production", testing=False, on_startup=False):
     # start by configuring the logger
     logging.basicConfig(
         level=logging.INFO,
-        format='%(asctime)s %(levelname)s %(name)s %(threadName)s : %(message)s')
+        format="%(asctime)s %(levelname)s %(name)s %(threadName)s : %(message)s",
+    )
 
     # ok, we can now create our app
     app = Flask(__name__)

--- a/api/app/__init__.py
+++ b/api/app/__init__.py
@@ -3,6 +3,7 @@ This contains the initial creation of dataset in dev
 mode and the initialisation of the applicaton.
 """
 import os
+import logging
 
 from flask import Blueprint, Flask
 from flask_restx import Api
@@ -14,9 +15,16 @@ from app.healthz import healthz
 from app.redirect import redirect_to_api
 
 
-def create_app(environment="production", testing=False):
+def create_app(environment="production", testing=False, on_startup=False):
     """Create the application and set the configuration.
     By default, testing mode is set to False."""
+
+    # start by configuring the logger
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(asctime)s %(levelname)s %(name)s %(threadName)s : %(message)s')
+
+    # ok, we can now create our app
     app = Flask(__name__)
     app.config["TESTING"] = testing
     app.config["MAX_CONTENT_LENGTH"] = 16 * 1024 * 1024
@@ -47,6 +55,7 @@ def create_app(environment="production", testing=False):
     app.register_blueprint(healthz)
     app.teardown_appcontext(db.teardown_db)
     with app.app_context():
-        if not app.testing:
+        if on_startup:
+            # we want to initalize enermaps datasets only at startup
             data_controller.init_enermaps_datasets()
     return app

--- a/api/app/__init__.py
+++ b/api/app/__init__.py
@@ -2,8 +2,8 @@
 This contains the initial creation of dataset in dev
 mode and the initialisation of the applicaton.
 """
-import os
 import logging
+import os
 
 from flask import Blueprint, Flask
 from flask_restx import Api

--- a/api/app/data_integration/data_controller.py
+++ b/api/app/data_integration/data_controller.py
@@ -1,3 +1,7 @@
+import time
+
+from flask import current_app
+
 from app.data_integration import data_endpoints, enermaps_server
 from app.models.geofile import create
 
@@ -8,12 +12,18 @@ def init_enermaps_datasets():
     nuts_and_lau_datasets = ["country", "NUTS1", "NUTS2", "NUTS3", "LAU"]
     for dataset_name in nuts_and_lau_datasets:
         try:
+            time_started = time.time()
+            current_app.logger.info(f'Get/update nuts/lau <{dataset_name}>...')
             file_upload = enermaps_server.get_nuts_and_lau_dataset(dataset_name)
+            time_fetched = time.time()
+            current_app.logger.info(f'... fetch done in {int(time_fetched - time_started)} seconds')
             if file_upload is not None:
                 create(file_upload)
+                time_saved = time.time()
+                current_app.logger.info(f'... save done in {int(time_saved - time_fetched)} seconds.')
         except Exception as e:
-            print("Error creating dataset {}".format(dataset_name))
-            print(e)
+            current_app.logger.error("Error creating dataset {}".format(dataset_name))
+            current_app.logger.error(e)
 
     # Get the ids of the datasets that we want to load
     datasets_ids = data_endpoints.get_ds_ids()
@@ -22,9 +32,15 @@ def init_enermaps_datasets():
     # Check that the datasets that we want to load are in the enermaps DB
     for dataset_id in datasets_ids:
         try:
+            time_started = time.time()
+            current_app.logger.info(f'Get/update dataset <{dataset_id}>...')
             file_upload = enermaps_server.get_dataset(dataset_id)
+            time_fetched = time.time()
+            current_app.logger.info(f'... fetch done in {int(time_fetched - time_started)} seconds')
             if file_upload is not None:
                 create(file_upload)
+                time_saved = time.time()
+                current_app.logger.info(f'... save done in {int(time_saved - time_fetched)} seconds.')
         except Exception as e:
-            print("Error creating dataset {}".format(dataset_id))
-            print(e)
+            current_app.logger.error("Error creating dataset {}".format(dataset_id))
+            current_app.logger.error(e)

--- a/api/app/data_integration/data_controller.py
+++ b/api/app/data_integration/data_controller.py
@@ -13,14 +13,18 @@ def init_enermaps_datasets():
     for dataset_name in nuts_and_lau_datasets:
         try:
             time_started = time.time()
-            current_app.logger.info(f'Get/update nuts/lau <{dataset_name}>...')
+            current_app.logger.info(f"Get/update nuts/lau <{dataset_name}>...")
             file_upload = enermaps_server.get_nuts_and_lau_dataset(dataset_name)
             time_fetched = time.time()
-            current_app.logger.info(f'... fetch done in {int(time_fetched - time_started)} seconds')
+            current_app.logger.info(
+                f"... fetch done in {int(time_fetched - time_started)} seconds"
+            )
             if file_upload is not None:
                 create(file_upload)
                 time_saved = time.time()
-                current_app.logger.info(f'... save done in {int(time_saved - time_fetched)} seconds.')
+                current_app.logger.info(
+                    f"... save done in {int(time_saved - time_fetched)} seconds."
+                )
         except Exception as e:
             current_app.logger.error("Error creating dataset {}".format(dataset_name))
             current_app.logger.error(e)
@@ -33,14 +37,18 @@ def init_enermaps_datasets():
     for dataset_id in datasets_ids:
         try:
             time_started = time.time()
-            current_app.logger.info(f'Get/update dataset <{dataset_id}>...')
+            current_app.logger.info(f"Get/update dataset <{dataset_id}>...")
             file_upload = enermaps_server.get_dataset(dataset_id)
             time_fetched = time.time()
-            current_app.logger.info(f'... fetch done in {int(time_fetched - time_started)} seconds')
+            current_app.logger.info(
+                f"... fetch done in {int(time_fetched - time_started)} seconds"
+            )
             if file_upload is not None:
                 create(file_upload)
                 time_saved = time.time()
-                current_app.logger.info(f'... save done in {int(time_saved - time_fetched)} seconds.')
+                current_app.logger.info(
+                    f"... save done in {int(time_saved - time_fetched)} seconds."
+                )
         except Exception as e:
             current_app.logger.error("Error creating dataset {}".format(dataset_id))
             current_app.logger.error(e)

--- a/api/app/data_integration/enermaps_server.py
+++ b/api/app/data_integration/enermaps_server.py
@@ -48,7 +48,7 @@ def get_dataset(dataset_id):
 
     if (params is not None) and (layer_type == "vector"):
         try:
-            headers={"Authorization": "Bearer {}".format(DATASETS_SERVER_API_KEY)}
+            headers = {"Authorization": "Bearer {}".format(DATASETS_SERVER_API_KEY)}
             with requests.post(url, headers=headers, json=params) as resp:
                 # TODO check here that we have recieved a valid geojson?
                 geojson = resp.json()
@@ -77,7 +77,7 @@ def get_dataset(dataset_id):
         # on another server
         file_name = None
         try:
-            headers={"Authorization": "Bearer {}".format(DATASETS_SERVER_API_KEY)}
+            headers = {"Authorization": "Bearer {}".format(DATASETS_SERVER_API_KEY)}
             with requests.post(url, headers=headers, json=params) as resp:
                 resp_data = resp.json()
 

--- a/api/app/data_integration/enermaps_server.py
+++ b/api/app/data_integration/enermaps_server.py
@@ -23,11 +23,8 @@ def get_nuts_and_lau_dataset(dataset_name):
         "row_limit": 100000,
     }
     try:
-        with requests.post(
-            url,
-            headers={"Authorization": "Bearer {}".format(DATASETS_SERVER_API_KEY)},
-            json=params,
-        ) as resp:
+        headers = {"Authorization": "Bearer {}".format(DATASETS_SERVER_API_KEY)}
+        with requests.post(url, headers=headers, json=params) as resp:
             # TODO check here that we have recieved a valid geojson?
             resp_data = io.BytesIO(resp.content)
 
@@ -50,13 +47,9 @@ def get_dataset(dataset_id):
     dataset_title = data_endpoints.get_ds_title(dataset_id)
 
     if (params is not None) and (layer_type == "vector"):
-        print("Fetching json dataset " + str(dataset_id))
         try:
-            with requests.post(
-                url,
-                headers={"Authorization": "Bearer {}".format(DATASETS_SERVER_API_KEY)},
-                json=params,
-            ) as resp:
+            headers={"Authorization": "Bearer {}".format(DATASETS_SERVER_API_KEY)}
+            with requests.post(url, headers=headers, json=params) as resp:
                 # TODO check here that we have recieved a valid geojson?
                 geojson = resp.json()
                 for i in range(len(geojson["features"])):
@@ -80,16 +73,12 @@ def get_dataset(dataset_id):
             raise
 
     if (params is not None) and (layer_type == "raster"):
-        print("Fetching raster dataset " + str(dataset_id))
         # We need to get the dataset info from the db before downloading the files
         # on another server
         file_name = None
         try:
-            with requests.post(
-                url,
-                headers={"Authorization": "Bearer {}".format(DATASETS_SERVER_API_KEY)},
-                json=params,
-            ) as resp:
+            headers={"Authorization": "Bearer {}".format(DATASETS_SERVER_API_KEY)}
+            with requests.post(url, headers=headers, json=params) as resp:
                 resp_data = resp.json()
 
                 # If there is multiple images to download, download only the 1st one

--- a/api/gunicorn.py
+++ b/api/gunicorn.py
@@ -3,10 +3,10 @@ we need to keep this file in python (see
 https://github.com/benoitc/gunicorn/blob/master/examples/example_config.py)
 for an example.
 """
+import datetime
+import logging
 import multiprocessing
 import sys
-import logging
-import datetime
 
 from app import create_app
 

--- a/api/gunicorn.py
+++ b/api/gunicorn.py
@@ -5,6 +5,8 @@ for an example.
 """
 import multiprocessing
 import sys
+import logging
+import datetime
 
 from app import create_app
 
@@ -18,8 +20,14 @@ def on_starting(_):
     run upon app creation, so we just create a dummy application to trigger
     those hooks
     """
-    print("Running the startup hook ", flush=True)
-    create_app()
-    print("startup hook finished")
+
+    # the logging system will be confirgured at app creation,
+    # so, don't use it before
+    print(f"{datetime.datetime.now()}: Running the startup hook ", flush=True)
+
+    # initialize the local cache of the datasets
+    create_app(on_startup=True)
+
+    logging.info("startup hook finished")
     #  Explicitely flush so that we have the init logs
     sys.stdout.flush()


### PR DESCRIPTION
This patch limit the fetch of the datasets to only one per dataset
before the backend api server start to serve requests.