### PR TITLE
Cm outputs cleanup

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -8,16 +8,17 @@ RUN apt update && apt install --yes \
     python3-gunicorn \
     gunicorn \
     libpq-dev \
-    python3-gdal && \
+    python3-gdal \
+    cron && \
     rm -rf /var/cache/apt/archives/
 
-VOLUME /upload
 WORKDIR /api
 COPY requirements.txt requirements.txt
 RUN pip3 install -r requirements.txt
 COPY . .
+
 #always ensure the python test are fine before proceeding to build the image
 RUN python3 test.py
 
 EXPOSE 80
-CMD ["gunicorn", "--config", "gunicorn.py", "--bind", "0.0.0.0:80", "wsgi:app"]
+ENTRYPOINT scripts/entrypoint.sh

--- a/api/app/models/geofile.py
+++ b/api/app/models/geofile.py
@@ -205,6 +205,10 @@ class RasterLayer(Layer):
         non_hidden_layers = filter(lambda a: not a.startswith("."), layers)
         return map(RasterLayer, non_hidden_layers)
 
+    @classmethod
+    def _convert_name(cls, name):
+        return name
+
     def _get_raster_dir(self):
         """Return the path to the directory containing the raster path"""
         raster_dir = safe_join(get_user_upload(self.FOLDER), self.name)
@@ -244,7 +248,7 @@ class RasterLayer(Layer):
         * the layer is saved in a temporary directory as tiff.
           -> path : /upload-dir/tmp/raster.tiff,
         * and then replace its in the raster directory.
-          -> path : /upload-dir/raster/(file_upload_filename)/raster.tiff.
+          -> path : /upload-dir/{FOLDER}/(file_upload_filename)/raster.tiff.
 
         An error is raised if the geofile already exists.
         """
@@ -252,8 +256,10 @@ class RasterLayer(Layer):
             tmp_filepath = safe_join(tmp_dir, RasterLayer._RASTER_NAME)
             file_upload.save(tmp_filepath)
             output_filepath = safe_join(
-                get_user_upload(cls.FOLDER), file_upload.filename
+                get_user_upload(cls.FOLDER), cls._convert_name(file_upload.filename)
             )
+            parent, _ = os.path.split(output_filepath)
+            os.makedirs(parent, exist_ok=True)
             # replace will replace the file if it already exists, we should first check
             # if the file already exists before proceeding
             try:
@@ -293,6 +299,47 @@ class RasterLayer(Layer):
 class CMRasterLayer(RasterLayer):
 
     FOLDER = "cm_output"
+
+    def __init__(self, name):
+        super().__init__(name)
+        self.folder_name = self._convert_name(name)
+
+    @classmethod
+    def list_layers(cls):
+        """As we store rasters on disk, we only want to list
+        files in the directory.
+        """
+        root_folder = get_user_upload(cls.FOLDER)
+
+        layers = []
+        for root, dirs, files in os.walk(root_folder):
+            if files:
+                _, name = os.path.split(root)
+                layers.append(name)
+
+        non_hidden_layers = filter(lambda a: not a.startswith("."), layers)
+
+        return map(CMRasterLayer, non_hidden_layers)
+
+    @classmethod
+    def _convert_name(cls, name):
+        parts = name.split("_")
+
+        if parts[-1].find("-") >= 0:
+            prefix = parts[-1].split("-")[0]
+            parts = parts[:-1]
+
+            for i in range(0, len(prefix), 2):
+                parts.append(prefix[i : i + 2])
+
+        parts.append(name)
+
+        return os.path.sep.join(parts)
+
+    def _get_raster_dir(self):
+        """Return the path to the directory containing the raster path"""
+        raster_dir = safe_join(get_user_upload(self.FOLDER), self.folder_name)
+        return raster_dir
 
     def touch(self):
         """Sets the modification and access times of files to the current time of day"""

--- a/api/app/models/geofile.py
+++ b/api/app/models/geofile.py
@@ -5,7 +5,6 @@ really prevent race condition on list vs delete. We
 also catch those on accessing the layer.
 
 """
-import functools
 import io
 import os
 import shutil
@@ -84,7 +83,6 @@ def create(file_upload: FileStorage, is_cm_output=False):
     raise Exception("Unknown file format {}".format(file_upload.mimetype))
 
 
-@functools.lru_cache
 def load(name):
     """Create a new instance of RasterLayer based on its name"""
     if name.startswith("cm_outputs/"):
@@ -97,10 +95,13 @@ def load(name):
         return RasterLayer(name)
 
 
-@functools.lru_cache
 def load_cm_output(name):
     """Create a new instance of RasterLayer based on its name"""
-    return CMRasterLayer(name)
+    layer = CMRasterLayer(name)
+    if layer.exists():
+        return layer
+
+    raise FileNotFoundError
 
 
 class Layer(ABC):

--- a/api/app/models/geofile.py
+++ b/api/app/models/geofile.py
@@ -12,6 +12,7 @@ import subprocess  # nosec
 import zipfile
 from abc import ABC, abstractmethod
 from glob import glob
+from pathlib import Path
 from tempfile import TemporaryDirectory
 
 import mapnik
@@ -99,6 +100,7 @@ def load_cm_output(name):
     """Create a new instance of RasterLayer based on its name"""
     layer = CMRasterLayer(name)
     if layer.exists():
+        layer.touch()
         return layer
 
     raise FileNotFoundError
@@ -291,6 +293,10 @@ class RasterLayer(Layer):
 class CMRasterLayer(RasterLayer):
 
     FOLDER = "cm_output"
+
+    def touch(self):
+        """Sets the modification and access times of files to the current time of day"""
+        Path(self._get_raster_path()).touch()
 
 
 class VectorLayer(Layer):

--- a/api/scripts/clean_cm_outputs.py
+++ b/api/scripts/clean_cm_outputs.py
@@ -16,21 +16,29 @@ cm_outputs_dir = os.path.join(upload_dir, "cm_output")
 now = datetime.utcnow()
 max_age = timedelta(hours=1)
 
-to_delete = []
+files_to_delete = []
+folders_to_delete = []
 
 for root, dirs, files in os.walk(cm_outputs_dir):
-    for filename in files:
-        fullpath = os.path.join(root, filename)
-        access_time = datetime.utcfromtimestamp(os.path.getatime(fullpath))
+    if files:
+        for filename in files:
+            fullpath = os.path.join(root, filename)
+            access_time = datetime.utcfromtimestamp(os.path.getatime(fullpath))
 
-        if (now - access_time) > max_age:
-            to_delete.append(fullpath.replace(cm_outputs_dir + os.path.sep, ""))
+            if (now - access_time) > max_age:
+                files_to_delete.append(
+                    fullpath.replace(cm_outputs_dir + os.path.sep, "")
+                )
+                folders_to_delete.append(root.replace(cm_outputs_dir + os.path.sep, ""))
+    elif not dirs:
+        folders_to_delete.append(root.replace(cm_outputs_dir + os.path.sep, ""))
 
 
 # Delete the files and any empty directory left after
 os.chdir(cm_outputs_dir)
 
-for filename in to_delete:
+for filename in files_to_delete:
     os.remove(filename)
-    path, _ = os.path.split(filename)
+
+for path in folders_to_delete:
     os.removedirs(path)

--- a/api/scripts/clean_cm_outputs.py
+++ b/api/scripts/clean_cm_outputs.py
@@ -1,0 +1,36 @@
+"""Delete CM outputs files that haven't been accessed recently"""
+
+import os
+import sys
+from datetime import datetime, timedelta
+
+# Retrieve the root folder of the CM outputs
+upload_dir = os.environ.get("UPLOAD_DIR", None)
+if upload_dir is None:
+    sys.exit(1)
+
+cm_outputs_dir = os.path.join(upload_dir, "cm_output")
+
+
+# Find all the files to delete
+now = datetime.utcnow()
+max_age = timedelta(hours=1)
+
+to_delete = []
+
+for root, dirs, files in os.walk(cm_outputs_dir):
+    for filename in files:
+        fullpath = os.path.join(root, filename)
+        access_time = datetime.utcfromtimestamp(os.path.getatime(fullpath))
+
+        if (now - access_time) > max_age:
+            to_delete.append(fullpath.replace(cm_outputs_dir + os.path.sep, ""))
+
+
+# Delete the files and any empty directory left after
+os.chdir(cm_outputs_dir)
+
+for filename in to_delete:
+    os.remove(filename)
+    path, _ = os.path.split(filename)
+    os.removedirs(path)

--- a/api/scripts/entrypoint.sh
+++ b/api/scripts/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+declare -p | grep -Ev 'BASHOPTS|BASH_VERSINFO|EUID|PPID|SHELLOPTS|UID' > /container.env
+
+# Setup a cron job
+echo "SHELL=/bin/bash
+BASH_ENV=/container.env
+*/5 * * * * root python3 /api/scripts/clean_cm_outputs.py
+" > /etc/cron.d/clean_cm_outputs
+
+service cron start
+
+# Start the web server
+gunicorn --config gunicorn.py --bind 0.0.0.0:80 wsgi:app

--- a/cm/cm_heat_demand/tools/geofile.py
+++ b/cm/cm_heat_demand/tools/geofile.py
@@ -1,6 +1,6 @@
 import json
 import tempfile
-from os import close, remove, system
+from os import remove, system
 from os.path import exists, isfile, splitext
 
 import numpy as np
@@ -38,10 +38,8 @@ def clip_raster(src: str, shapes: dict, dst: str, quiet: bool = True):
         * projection : projection of the clipped raster.
     """
 
-    (file, cutline) = tempfile.mkstemp()
-    close(file)
-
-    with open(cutline, "w") as file:
+    (fd, cutline) = tempfile.mkstemp()
+    with open(fd, "w") as file:
         json.dump(shapes, file)
 
     command = (

--- a/cm/cm_heat_demand/tools/geofile.py
+++ b/cm/cm_heat_demand/tools/geofile.py
@@ -1,5 +1,6 @@
 import json
-from os import remove, system
+import tempfile
+from os import close, remove, system
 from os.path import exists, isfile, splitext
 
 import numpy as np
@@ -37,14 +38,18 @@ def clip_raster(src: str, shapes: dict, dst: str, quiet: bool = True):
         * projection : projection of the clipped raster.
     """
 
-    cutline = "cutline.json"
+    (file, cutline) = tempfile.mkstemp()
+    close(file)
+
     with open(cutline, "w") as file:
         json.dump(shapes, file)
+
     command = (
         f'gdalwarp -cutline {cutline} -crop_to_cutline -dstnodata 0 "{src}" "{dst}"'
     )
     if quiet:
         command += " -q"
+
     system(command=command)
     remove(cutline)
 

--- a/frontend/src/src/client.js
+++ b/frontend/src/src/client.js
@@ -8,7 +8,6 @@ export async function getLayerType(layerId) {
     return {};
   }
   const legend = await response.json();
-  console.log(legend);
   return legend;
 }
 
@@ -18,7 +17,6 @@ export async function getLegend(layerId) {
     return {};
   }
   const legend = await response.json();
-  console.log(legend);
   return legend;
 }
 
@@ -28,7 +26,6 @@ export async function getOpenairLink(layerId) {
     return {};
   }
   const legend = await response.json();
-  console.log(legend);
   return legend;
 }
 
@@ -45,7 +42,6 @@ export async function getCMs() {
 export async function getGeofiles() {
   const response = await fetch(BASE_URL + 'api/geofile');
   if (!response.ok) {
-    console.log(response);
     return [];
   }
   const layersResponse = await response.json();

--- a/frontend/src/src/components/AreaSelection.svelte
+++ b/frontend/src/src/components/AreaSelection.svelte
@@ -35,9 +35,8 @@
 
   onMount(async () => {
     const layers = await getGeofiles();
-    for (const [layer, layerParameters] of Object.entries(layers)) {
+    for (const layer of Object.keys(layers)) {
       let leafletLayer;
-      console.log(layer, layerParameters);
       if (SELECTIONS.has(layer)) {
         // We can put something else than the full name of the file
         function convertName(layer) {
@@ -88,7 +87,9 @@
   }
 
   $: {
-    console.log('layer changed in selector to ' + $activeSelectionLayerStore);
+    if ($activeSelectionLayerStore !== undefined) {
+      console.log('Active area changed to ' + $activeSelectionLayerStore.name);
+    }
   }
 </script>
 

--- a/frontend/src/src/components/CM.svelte
+++ b/frontend/src/src/components/CM.svelte
@@ -27,6 +27,20 @@
     tasks = tasks;
   }
 
+
+  async function refreshTask(task) {
+    const index = tasks.indexOf(task);
+    tasks.splice(index, 1);
+    tasks = tasks;
+
+    console.log('Refreshing task with parameters: ' + task.parameters);
+    const newTask = await postCMTask(cm, task.parameters);
+
+    tasks.splice(index, 0, newTask);
+    tasks = tasks;
+  }
+
+
   onMount(() => {
     form = BrutusinForms.create(cm.schema);
     form.render(formElement);
@@ -120,7 +134,7 @@
     <div class="cm_params" bind:this={formElement} />
     <div class="tasks">
       {#each [...tasks].reverse() as task (task.id)}
-        <CMTask {cm} {task}  on:delete="{() => deleteCMTask(task)}" />
+        <CMTask {cm} {task} on:delete="{() => deleteCMTask(task)}" on:refresh="{() => refreshTask(task)}" />
       {/each}
     </div>
   </div>

--- a/frontend/src/src/components/CM.svelte
+++ b/frontend/src/src/components/CM.svelte
@@ -20,23 +20,34 @@
     newTaskParams['selection'] = $activeSelectionLayerStore.getSelection();
     newTaskParams['layers'] = $activeOverlayLayersStore.map((layer)=>layer.name);
     newTaskParams['parameters'] = form.getData();
-    console.log('Creating new task with parameters: ' + newTaskParams);
+
+    console.log(
+        '[CM ' + cm.name + '] Creating new task with parameters:',
+        newTaskParams.parameters,
+    );
+
     const task = await postCMTask(cm, newTaskParams);
+    console.log('[CM ' + cm.name + '] Created task: ' + task.id);
 
     tasks.push(task);
+    console.log('[CM ' + cm.name + '] Active tasks:', tasks.map((x) => x.id));
+
     tasks = tasks;
   }
 
 
   async function refreshTask(task) {
-    const index = tasks.indexOf(task);
-    tasks.splice(index, 1);
-    tasks = tasks;
+    console.log('[CM ' + cm.name + '] Refreshing task ' + task.id +
+                ' with parameters:', task.parameters.parameters);
 
-    console.log('Refreshing task with parameters: ' + task.parameters);
     const newTask = await postCMTask(cm, task.parameters);
+    console.log('[CM ' + cm.name + '] Created task: ' + newTask.id +
+                ' to replace ' + task.id);
 
-    tasks.splice(index, 0, newTask);
+    const index = tasks.indexOf(task);
+    tasks.splice(index, 1, newTask);
+    console.log('[CM ' + cm.name + '] Active tasks:', tasks.map((x) => x.id));
+
     tasks = tasks;
   }
 
@@ -64,7 +75,7 @@
   }
 
   function deleteCMTask(taskToDelete) {
-    console.log('Deleting task: ' + taskToDelete.id);
+    console.log('[CM ' + cm.name + '] Deleting task: ' + taskToDelete.id);
     tasks = tasks.filter((task)=> taskToDelete.id != task.id);
   }
 </script>

--- a/frontend/src/src/components/CMTask.svelte
+++ b/frontend/src/src/components/CMTask.svelte
@@ -90,6 +90,8 @@
             },
         );
 
+        layer.on('tileerror', onTileError);
+
         layers.push(layer);
         activeLayers.push(layer);
       }
@@ -104,6 +106,31 @@
     $activeCMOutputLayersStore = activeLayers;
 
     resultsDisplayed = !resultsDisplayed;
+  }
+
+  function onTileError() {
+    if (!isTaskPending) {
+      // Reset the component
+      graphs = {};
+      values = [];
+      taskResult = {status: 'PENDING'};
+      isTaskPending = true;
+      isTaskFailed = false;
+      resultsDisplayed = false;
+
+      // Destroy the layers
+      let activeLayers = $activeCMOutputLayersStore;
+
+      for (const layer of layers) {
+        activeLayers = activeLayers.filter((item) => item !== layer);
+      }
+
+      layers = [];
+      $activeCMOutputLayersStore = activeLayers;
+
+      // Refresh the task
+      dispatch('refresh', {});
+    }
   }
 
   function removeTask() {

--- a/frontend/src/src/components/CMTask.svelte
+++ b/frontend/src/src/components/CMTask.svelte
@@ -22,6 +22,7 @@
   const PENDING_STATUS = 'PENDING';
   const FAILURE_STATUS = 'FAILURE';
   const REVOKED_STATUS = 'REVOKED';
+  const REFRESHING_STATUS = 'REFRESHING';
   const dispatch = createEventDispatcher();
 
   onMount(async () => {
@@ -53,7 +54,8 @@
       console.log('[CMTask ' + task.id + '] Revoked');
       removeTask();
     } else if (isTaskPending) {
-      isTaskPending = (taskResult.status === PENDING_STATUS);
+      isTaskPending = (taskResult.status === PENDING_STATUS) ||
+                      (taskResult.status === REFRESHING_STATUS);
       isTaskFailed = (taskResult.status === FAILURE_STATUS);
 
       if (!isTaskPending) {
@@ -125,7 +127,7 @@
       // Reset the component
       graphs = {};
       values = [];
-      taskResult = {status: 'PENDING'};
+      taskResult = {status: REFRESHING_STATUS};
       isTaskPending = true;
       isTaskFailed = false;
       resultsDisplayed = false;

--- a/frontend/src/src/components/CMTask.svelte
+++ b/frontend/src/src/components/CMTask.svelte
@@ -231,6 +231,10 @@
     <dl>
       <dt><strong>task_id</strong></dt><dd>{formatTaskID(task)}</dd>
       <dt><strong>status</strong></dt><dd>{taskResult.status}</dd>
+
+      {#if isTaskFailed}
+        <dt><strong>error</strong></dt><dd>{taskResult.result}</dd>
+      {/if}
     </dl>
   {:else}
     <div class="tabs">

--- a/frontend/src/src/components/CMTask.svelte
+++ b/frontend/src/src/components/CMTask.svelte
@@ -50,8 +50,9 @@
 
   $: {
     if (taskResult.status === REVOKED_STATUS) {
+      console.log('[CMTask ' + task.id + '] Revoked');
       removeTask();
-    } else {
+    } else if (isTaskPending) {
       isTaskPending = (taskResult.status === PENDING_STATUS);
       isTaskFailed = (taskResult.status === FAILURE_STATUS);
 
@@ -66,6 +67,8 @@
 
         parameters = Object.entries(task.parameters.parameters);
 
+        console.log('[CMTask ' + task.id + '] Got response: ' + taskResult.status);
+
         if (!isTaskFailed) {
           showHideResults();
         }
@@ -77,6 +80,7 @@
     let activeLayers = $activeCMOutputLayersStore;
 
     if (!resultsDisplayed) {
+      let index = 0;
       for (const value of Object.values(taskResult.result.geofiles)) {
         let layerName = value.split('/');
         layerName = layerName[layerName.length-2] + '/' + layerName[layerName.length-1];
@@ -90,12 +94,20 @@
             },
         );
 
+        layer.id = task.id + '/' + index;
+
         layer.on('tileerror', onTileError);
 
         layers.push(layer);
         activeLayers.push(layer);
+
+        ++index;
       }
+
+      console.log('[CMTask ' + task.id + '] Created layers:', layers.map((x) => x.id));
     } else {
+      console.log('[CMTask ' + task.id + '] Destroying layers:', layers.map((x) => x.id));
+
       for (const layer of layers) {
         activeLayers = activeLayers.filter((item) => item !== layer);
       }

--- a/frontend/src/src/components/Chart.svelte
+++ b/frontend/src/src/components/Chart.svelte
@@ -17,7 +17,6 @@
 
   function processDatasets() {
     for (const [datasetName, dataset] of Object.entries(datasets)) {
-      console.log('inserting dataset ' + datasetName);
       insertDataset(datasetName, dataset);
     }
   }
@@ -25,22 +24,18 @@
   function insertDataset(name, dataset) {
     const values = dataset.values;
     if (values.length === 0) {
-      console.log('empty graph ' + name + ', skip this graph');
       return;
     }
     const graphType = dataset.type;
     switch (graphType) {
       case 'xy':
         insertXYChart(name, dataset);
-        console.log('Graph type : XY');
         break;
       case 'bar':
         insertBarChart(name, dataset);
-        console.log('Graph type : BAR');
         break;
       case 'line':
         insertLineChart(name, dataset);
-        console.log('Graph type : LINE');
         break;
       default:
     }

--- a/frontend/src/src/components/LayerSelection.svelte
+++ b/frontend/src/src/components/LayerSelection.svelte
@@ -52,15 +52,10 @@
     const layers = await getGeofiles();
     for (const [layer, layerParameters] of Object.entries(layers)) {
       let leafletLayer;
-      console.log(layer, layerParameters);
       if (!SELECTIONS.has(layer)) {
         const legend = getLegend(layer);
-        console.log(legend);
         const layerType = getLayerType(layer);
-        console.log(layerType);
-
         const openairLink = getOpenairLink(layer);
-        console.log(openairLink);
 
         if (layerParameters.isQueryable) {
           leafletLayer = toQueryableLayer(layer);
@@ -108,7 +103,7 @@
   });
 
   $: {
-    console.log('layer changed in selector to ' + $activeOverlayLayersStore);
+    console.log('Active layers changed to', $activeOverlayLayersStore.map((x) => x.name));
     filteredOverlayLayers = overlayLayers.filter((layer) =>
       layer.name.toLowerCase().indexOf(overlayLayersFilter.toLowerCase()) !== -1);
   }

--- a/frontend/src/src/components/Map.svelte
+++ b/frontend/src/src/components/Map.svelte
@@ -22,9 +22,9 @@
   import {BASE_LAYER_PARAMS} from '../settings.js';
 
   let map;
-  $: activeSelectionLayer = $activeSelectionLayerStore;
-  $: activeOverlayLayers = $activeOverlayLayersStore;
-  $: activeCMOutputLayers = $activeCMOutputLayersStore;
+  let activeSelectionLayer;
+  let activeOverlayLayers;
+  let activeCMOutputLayers;
 
   const cmOutputsGroup = L.layerGroup();
   const overlaysGroup = L.layerGroup();
@@ -57,9 +57,10 @@
   }
 
   $: {
-    console.log(`selected layer was changed: ${activeSelectionLayer}`);
-    console.log(`overlay layer was changed: ${activeOverlayLayers}`);
-    console.log(`CM output layer was changed: ${activeCMOutputLayers}`);
+    activeSelectionLayer = $activeSelectionLayerStore;
+    activeOverlayLayers = $activeOverlayLayersStore;
+    activeCMOutputLayers = $activeCMOutputLayersStore;
+
     syncSelectionLayer();
     syncOverlayLayers();
     syncCMOutputLayers();
@@ -69,12 +70,14 @@
     const overlayToBePruned = new Set(overlaysGroup.getLayers());
     for (const activeOverlayLayer of activeOverlayLayers) {
       if (!overlaysGroup.hasLayer(activeOverlayLayer)) {
+        console.log('[Map] Add overlay layer: ' + activeOverlayLayer.name);
         overlaysGroup.addLayer(activeOverlayLayer);
       } else {
         overlayToBePruned.delete(activeOverlayLayer);
       }
     }
     for (const overlay of overlayToBePruned) {
+      console.log('[Map] Remove overlay layer: ' + overlay.name);
       overlaysGroup.removeLayer(overlay);
     }
   }
@@ -96,12 +99,14 @@
     const cmOutputsToBePruned = new Set(cmOutputsGroup.getLayers());
     for (const activeCMOutputLayer of activeCMOutputLayers) {
       if (!cmOutputsGroup.hasLayer(activeCMOutputLayer)) {
+        console.log('[Map] Add CM output layer: ' + activeCMOutputLayer.id);
         cmOutputsGroup.addLayer(activeCMOutputLayer);
       } else {
         cmOutputsToBePruned.delete(activeCMOutputLayer);
       }
     }
     for (const cmOutput of cmOutputsToBePruned) {
+      console.log('[Map] Remove CM output layer: ' + cmOutput.id);
       cmOutputsGroup.removeLayer(cmOutput);
     }
   }

--- a/frontend/src/src/components/Value.svelte
+++ b/frontend/src/src/components/Value.svelte
@@ -6,7 +6,6 @@
 
   $: {
     name = value[0];
-    console.log(value);
     if (Array.isArray(value[1])) {
       formattedValue = value[1].map(String).join(' ');
     } else {

--- a/frontend/src/src/leaflet_components/L.TileLayer.NutsLayer.js
+++ b/frontend/src/src/leaflet_components/L.TileLayer.NutsLayer.js
@@ -89,7 +89,6 @@ L.TileLayer.NutsLayer = L.TileLayer.WMS.extend({
     // Otherwise show the content in a popup, or something.
     // this._map.getLayer("selection")
     // check if we already clicked to toggle the selection
-    console.log('check click');
     // this._map.removeLayer(this.selection);
     // to be replaced by a dict to find the data per id
     for (const feature of content.features) {
@@ -106,7 +105,6 @@ L.TileLayer.NutsLayer = L.TileLayer.WMS.extend({
         this.selection.addData(feature);
       }
     }
-    console.log(this.selection.toGeoJSON().features.map(this.getFeatureId));
   },
 });
 


### PR DESCRIPTION
This PR ensures that the output files written by the CMs are deleted if not accessed for some time (set at 1 hour). Should an user need one file after its deletion, the frontend will start the CM again, using the original parameters.

As a side-effect, the logging done in the console of the web browser was improved to produce more useful debugging informations and remove the irrelevant ones.