### PR TITLE
Heatlearn tests

### DIFF
--- a/cm/heatlearn/Dockerfile
+++ b/cm/heatlearn/Dockerfile
@@ -14,13 +14,12 @@ RUN chmod 1777 /tmp && \
 ENV CPLUS_INCLUDE_PATH=/usr/include/gdal
 ENV C_INCLUDE_PATH=/usr/include/gdal
 
-COPY /.env-db-server /.env-db-server
-
 COPY cm/heatlearn/requirements.txt requirements.txt
 RUN pip3 install -r requirements.txt
 COPY cm/base /tmp/base
 RUN cd /tmp/base && pip3 install . && python3 test.py
 COPY cm/heatlearn .
 RUN mkdir -p tmp
+COPY /.env-db-server /.env-db-server
 RUN python3 test.py
 CMD ["python3", "worker.py"]


### PR DESCRIPTION
Don't contact the real database during the tests. This avoids issues on the production server where the database might not be running yet (and so the build can't succeed, and the database don't start).

I used the ```CH013_HDD.csv``` file to get some data, assuming the goal of the unit test is just to check if the code runs.

On a side note, if tests are not contacting the real database anymore, copying the ```.env-db-server``` inside the image might not be necessary anymore right? IIRC, the usual ```env_file``` mechanism of ```docker-compose``` would be sufficient for the ```CMD ["python3", "worker.py"]``` line.