### PR TITLE
Only send to CMs the raster files that intersect the selection area

### DIFF
--- a/api/app/models/geofile.py
+++ b/api/app/models/geofile.py
@@ -422,7 +422,7 @@ class RasterLayer(Layer):
 
         source_ref.ImportFromEPSG(project.epsg_string_to_epsg(bbox_projection))
         target_ref.ImportFromEPSG(
-            project.epsg_string_to_epsg(current_app.config["RASTER_PROJECTION_SYSTEM"])
+            project.epsg_string_to_epsg(current_app.config["VECTOR_PROJECTION_SYSTEM"])
         )
 
         t = osr.CoordinateTransformation(source_ref, target_ref)

--- a/api/app/models/geofile.py
+++ b/api/app/models/geofile.py
@@ -320,26 +320,7 @@ class RasterLayer(Layer):
         """Open the geofile as Mapnik layer."""
 
         # Only use as many raster files as necessary
-        rasters = []
-
-        geometries = self.storage.get_geometries(self.name)
-        if geometries is not None:
-            if (
-                (bbox is not None)
-                and (bbox_projection is not None)
-                and (geometries[next(iter(geometries))] is not None)
-            ):
-                rasters = self._get_rasters_in_bbox(geometries, bbox, bbox_projection)
-            else:
-                for feature_id in geometries.keys():
-                    rasters.append(
-                        (feature_id, self.storage.get_file_path(self.name, feature_id))
-                    )
-        else:
-            for feature_id in self.storage.list_feature_ids(self.name):
-                rasters.append(
-                    (feature_id, self.storage.get_file_path(self.name, feature_id))
-                )
+        rasters = self.get_rasters_in_bbox(bbox, bbox_projection)
 
         type = path.get_type(self.name)
 
@@ -372,13 +353,76 @@ class RasterLayer(Layer):
 
         return layers
 
-    def _get_rasters_in_bbox(self, geometries, bbox, bbox_projection):
+    def get_rasters_in_feature_list(self, features):
+        geometries = self.storage.get_geometries(self.name)
+
+        rasters = []
+
+        # No geometry file
+        if geometries is None:
+            for feature_id in self.storage.list_feature_ids(self.name):
+                rasters.append(
+                    (feature_id, self.storage.get_file_path(self.name, feature_id))
+                )
+            return rasters
+
+        # No polygon in the geometry file
+        if geometries[next(iter(geometries))] is None:
+            for feature_id in geometries.keys():
+                rasters.append(
+                    (feature_id, self.storage.get_file_path(self.name, feature_id))
+                )
+            return rasters
+
+        # Check the intersections
+        polygons = []
+
+        for feature in features:
+            for coordinates in feature["geometry"]["coordinates"]:
+                ring = ogr.Geometry(ogr.wkbLinearRing)
+
+                for p in coordinates:
+                    ring.AddPoint(p[0], p[1])
+
+                poly = ogr.Geometry(ogr.wkbPolygon)
+                poly.AddGeometry(ring)
+
+                polygons.append(poly)
+
+        return self._get_rasters_in_polygons(geometries, polygons)
+
+    def get_rasters_in_bbox(self, bbox, bbox_projection):
+        geometries = self.storage.get_geometries(self.name)
+
+        rasters = []
+
+        # No geometry file
+        if geometries is None:
+            for feature_id in self.storage.list_feature_ids(self.name):
+                rasters.append(
+                    (feature_id, self.storage.get_file_path(self.name, feature_id))
+                )
+            return rasters
+
+        # No polygon in the geometry file
+        if (
+            (bbox is None)
+            or (bbox_projection is None)
+            or (geometries[next(iter(geometries))] is None)
+        ):
+            for feature_id in geometries.keys():
+                rasters.append(
+                    (feature_id, self.storage.get_file_path(self.name, feature_id))
+                )
+            return rasters
+
+        # Check the intersections
         source_ref = osr.SpatialReference()
         target_ref = osr.SpatialReference()
 
         source_ref.ImportFromEPSG(project.epsg_string_to_epsg(bbox_projection))
         target_ref.ImportFromEPSG(
-            project.epsg_string_to_epsg(current_app.config["VECTOR_PROJECTION_SYSTEM"])
+            project.epsg_string_to_epsg(current_app.config["RASTER_PROJECTION_SYSTEM"])
         )
 
         t = osr.CoordinateTransformation(source_ref, target_ref)
@@ -396,6 +440,9 @@ class RasterLayer(Layer):
         bbox_poly = ogr.Geometry(ogr.wkbPolygon)
         bbox_poly.AddGeometry(bbox_ring)
 
+        return self._get_rasters_in_polygons(geometries, [bbox_poly])
+
+    def _get_rasters_in_polygons(self, geometries, polygons):
         rasters = []
 
         for feature_id, coordinates in geometries.items():
@@ -407,11 +454,13 @@ class RasterLayer(Layer):
             raster_poly = ogr.Geometry(ogr.wkbPolygon)
             raster_poly.AddGeometry(raster_ring)
 
-            intersection = bbox_poly.Intersection(raster_poly)
-            if intersection.GetGeometryCount() > 0:
-                rasters.append(
-                    (feature_id, self.storage.get_file_path(self.name, feature_id))
-                )
+            for polygon in polygons:
+                intersection = polygon.Intersection(raster_poly)
+                if intersection.GetGeometryCount() > 0:
+                    rasters.append(
+                        (feature_id, self.storage.get_file_path(self.name, feature_id))
+                    )
+                    break
 
         return rasters
 

--- a/api/app/models/test_geofile.py
+++ b/api/app/models/test_geofile.py
@@ -1,6 +1,9 @@
 import copy
 import json
 import os
+import shutil
+
+import mapnik
 
 from app.common import path
 from app.common.projection import epsg_string_to_proj4
@@ -424,3 +427,247 @@ class TestSaveCMParameters(BaseApiTest):
                 data = json.load(f)
 
             self.assertEqual(data, TestSaveCMParameters.PARAMETERS)
+
+
+class TestRasterLayerIntersections(BaseApiTest):
+    def setUp(self):
+        super().setUp()
+
+        with self.flask_app.app_context():
+            # Copy the raster dataset
+            layer_name = path.make_unique_layer_name(path.RASTER, 42, "heat")
+            storage_instance = storage.create(layer_name)
+
+            os.makedirs(storage_instance.get_dir(layer_name))
+
+            shutil.copy(
+                self.get_testdata_path("hotmaps-cdd_curr_adapted.tif"),
+                storage_instance.get_file_path(layer_name, "FID.tif"),
+            )
+
+            data = {"FID.tif": [[0, 60], [10, 60], [10, 30], [0, 30], [0, 60]]}
+
+            with open(storage_instance.get_geometries_file(layer_name), "w") as f:
+                json.dump(data, f)
+
+    def testIntersectsBoundingBox(self):
+        with self.flask_app.app_context():
+            layer_name = path.make_unique_layer_name(path.RASTER, 42, "heat")
+            layer = geofile.load(layer_name)
+
+            rasters = layer.get_rasters_in_bbox(
+                mapnik.Box2d(40, 0, 60, 10), "EPSG:3035"
+            )
+            self.assertEqual(len(rasters), 1)
+            self.assertEqual(
+                rasters[0],
+                (
+                    "FID.tif",
+                    layer.storage.get_file_path(layer_name, "FID.tif"),
+                ),
+            )
+
+    def testNotIntersectsBoundingBox(self):
+        with self.flask_app.app_context():
+            layer_name = path.make_unique_layer_name(path.RASTER, 42, "heat")
+            layer = geofile.load(layer_name)
+
+            rasters = layer.get_rasters_in_bbox(
+                mapnik.Box2d(40, -70, 60, -60), "EPSG:3035"
+            )
+            self.assertEqual(len(rasters), 0)
+
+    def testIntersectsOneFeatureOnePolygon(self):
+        with self.flask_app.app_context():
+            layer_name = path.make_unique_layer_name(path.RASTER, 42, "heat")
+            layer = geofile.load(layer_name)
+
+            features = [
+                {
+                    "geometry": {
+                        "coordinates": [[[5, 40], [8, 40], [8, 45], [5, 45], [5, 40]]]
+                    }
+                }
+            ]
+
+            rasters = layer.get_rasters_in_feature_list(features)
+            self.assertEqual(len(rasters), 1)
+            self.assertEqual(
+                rasters[0],
+                (
+                    "FID.tif",
+                    layer.storage.get_file_path(layer_name, "FID.tif"),
+                ),
+            )
+
+    def testIntersectsOneFeatureTwoPolygons(self):
+        with self.flask_app.app_context():
+            layer_name = path.make_unique_layer_name(path.RASTER, 42, "heat")
+            layer = geofile.load(layer_name)
+
+            features = [
+                {
+                    "geometry": {
+                        "coordinates": [
+                            [[5, 40], [8, 40], [8, 45], [5, 45], [5, 40]],
+                            [[5, 50], [8, 50], [8, 55], [5, 55], [5, 50]],
+                        ]
+                    }
+                }
+            ]
+
+            rasters = layer.get_rasters_in_feature_list(features)
+            self.assertEqual(len(rasters), 1)
+            self.assertEqual(
+                rasters[0],
+                (
+                    "FID.tif",
+                    layer.storage.get_file_path(layer_name, "FID.tif"),
+                ),
+            )
+
+    def testIntersectsOneFeatureTwoPolygons2(self):
+        with self.flask_app.app_context():
+            layer_name = path.make_unique_layer_name(path.RASTER, 42, "heat")
+            layer = geofile.load(layer_name)
+
+            features = [
+                {
+                    "geometry": {
+                        "coordinates": [
+                            [[-70, 40], [-60, 40], [-60, 45], [-70, 45], [-70, 40]],
+                            [[5, 50], [8, 50], [8, 55], [5, 55], [5, 50]],
+                        ]
+                    }
+                }
+            ]
+
+            rasters = layer.get_rasters_in_feature_list(features)
+            self.assertEqual(len(rasters), 1)
+            self.assertEqual(
+                rasters[0],
+                (
+                    "FID.tif",
+                    layer.storage.get_file_path(layer_name, "FID.tif"),
+                ),
+            )
+
+    def testIntersectsTwoFeaturesOnePolygon(self):
+        with self.flask_app.app_context():
+            layer_name = path.make_unique_layer_name(path.RASTER, 42, "heat")
+            layer = geofile.load(layer_name)
+
+            features = [
+                {
+                    "geometry": {
+                        "coordinates": [[[5, 40], [8, 40], [8, 45], [5, 45], [5, 40]]]
+                    }
+                },
+                {
+                    "geometry": {
+                        "coordinates": [[[5, 50], [8, 50], [8, 55], [5, 55], [5, 50]]]
+                    }
+                },
+            ]
+
+            rasters = layer.get_rasters_in_feature_list(features)
+            self.assertEqual(len(rasters), 1)
+            self.assertEqual(
+                rasters[0],
+                (
+                    "FID.tif",
+                    layer.storage.get_file_path(layer_name, "FID.tif"),
+                ),
+            )
+
+    def testIntersectsTwoFeaturesOnePolygon2(self):
+        with self.flask_app.app_context():
+            layer_name = path.make_unique_layer_name(path.RASTER, 42, "heat")
+            layer = geofile.load(layer_name)
+
+            features = [
+                {
+                    "geometry": {
+                        "coordinates": [
+                            [[-70, 40], [-60, 40], [-60, 45], [-70, 45], [-70, 40]]
+                        ]
+                    }
+                },
+                {
+                    "geometry": {
+                        "coordinates": [[[5, 50], [8, 50], [8, 55], [5, 55], [5, 50]]]
+                    }
+                },
+            ]
+
+            rasters = layer.get_rasters_in_feature_list(features)
+            self.assertEqual(len(rasters), 1)
+            self.assertEqual(
+                rasters[0],
+                (
+                    "FID.tif",
+                    layer.storage.get_file_path(layer_name, "FID.tif"),
+                ),
+            )
+
+    def testNotIntersectsOneFeatureOnePolygon(self):
+        with self.flask_app.app_context():
+            layer_name = path.make_unique_layer_name(path.RASTER, 42, "heat")
+            layer = geofile.load(layer_name)
+
+            features = [
+                {
+                    "geometry": {
+                        "coordinates": [
+                            [[-70, 40], [-60, 40], [-60, 45], [-70, 45], [-70, 40]]
+                        ]
+                    }
+                }
+            ]
+
+            rasters = layer.get_rasters_in_feature_list(features)
+            self.assertEqual(len(rasters), 0)
+
+    def testNotIntersectsOneFeatureTwoPolygons(self):
+        with self.flask_app.app_context():
+            layer_name = path.make_unique_layer_name(path.RASTER, 42, "heat")
+            layer = geofile.load(layer_name)
+
+            features = [
+                {
+                    "geometry": {
+                        "coordinates": [
+                            [[-70, 40], [-60, 40], [-60, 45], [-70, 45], [-70, 40]],
+                            [[-70, 50], [-60, 50], [-60, 55], [-70, 55], [-70, 50]],
+                        ]
+                    }
+                }
+            ]
+
+            rasters = layer.get_rasters_in_feature_list(features)
+            self.assertEqual(len(rasters), 0)
+
+    def testNotIntersectsTwoFeaturesOnePolygon(self):
+        with self.flask_app.app_context():
+            layer_name = path.make_unique_layer_name(path.RASTER, 42, "heat")
+            layer = geofile.load(layer_name)
+
+            features = [
+                {
+                    "geometry": {
+                        "coordinates": [
+                            [[-70, 40], [-60, 40], [-60, 45], [-70, 45], [-70, 40]]
+                        ]
+                    }
+                },
+                {
+                    "geometry": {
+                        "coordinates": [
+                            [[-70, 50], [-60, 50], [-60, 55], [-70, 55], [-70, 50]]
+                        ]
+                    }
+                },
+            ]
+
+            rasters = layer.get_rasters_in_feature_list(features)
+            self.assertEqual(len(rasters), 0)

--- a/api/app/models/test_geofile.py
+++ b/api/app/models/test_geofile.py
@@ -456,7 +456,7 @@ class TestRasterLayerIntersections(BaseApiTest):
             layer = geofile.load(layer_name)
 
             rasters = layer.get_rasters_in_bbox(
-                mapnik.Box2d(40, 0, 60, 10), "EPSG:3035"
+                mapnik.Box2d(40, 0, 60, 10), "EPSG:4326"
             )
             self.assertEqual(len(rasters), 1)
             self.assertEqual(
@@ -473,7 +473,7 @@ class TestRasterLayerIntersections(BaseApiTest):
             layer = geofile.load(layer_name)
 
             rasters = layer.get_rasters_in_bbox(
-                mapnik.Box2d(40, -70, 60, -60), "EPSG:3035"
+                mapnik.Box2d(40, -70, 60, -60), "EPSG:4326"
             )
             self.assertEqual(len(rasters), 0)
 


### PR DESCRIPTION
Same strategy than for the map creation in the WMS