### PR TITLE
fixes to make db buildable from empty volume

### DIFF
--- a/db/init/add_dataset_db.sql
+++ b/db/init/add_dataset_db.sql
@@ -3,7 +3,7 @@
 \set db_password `echo "${DB_PASSWORD}"`
 \set db_db `echo "${DB_DB}"`
 
-CREATE USER :db_user WITH UNENCRYPTED PASSWORD :'db_password';
+ALTER USER :db_user WITH UNENCRYPTED PASSWORD :'db_password';
 ALTER USER :db_user WITH LOGIN;
 CREATE DATABASE :db_db OWNER :'db_user';
 
@@ -49,7 +49,7 @@ CREATE TABLE public.data
     dt double precision,
     z double precision,
     isRaster boolean,
-    vis_id uuid;
+    vis_id uuid
 );
 
 CREATE TABLE public.visualization

--- a/db/init/postgrest.sql
+++ b/db/init/postgrest.sql
@@ -1,4 +1,7 @@
 -- POSTGREST
+\set db_db `echo "${DB_DB}"`
+\c :db_db;
+
 CREATE ROLE api_anon nologin;
 GRANT usage ON schema public TO api_anon;
 GRANT api_anon TO test;


### PR DESCRIPTION
Tested on a new database:
- the `:db_user` was already existing;
- the `posgrest.sql` needed to know on which db to be run;