### PR TITLE
CM heatlearn: Use the same environment variables mechanism than the other containers

### DIFF
--- a/cm/heatlearn/Dockerfile
+++ b/cm/heatlearn/Dockerfile
@@ -20,6 +20,5 @@ COPY cm/base /tmp/base
 RUN cd /tmp/base && pip3 install . && python3 test.py
 COPY cm/heatlearn .
 RUN mkdir -p tmp
-COPY /.env-db-server /.env-db-server
 RUN python3 test.py
 CMD ["python3", "worker.py"]

--- a/cm/heatlearn/heatlearn.py
+++ b/cm/heatlearn/heatlearn.py
@@ -24,15 +24,8 @@ from tensorflow.keras.backend import clear_session
 from tensorflow.keras.models import load_model
 
 # REST API for HDD
-env_db_server = ".env-db-server"
-if not os.path.exists(env_db_server):
-    raise FileNotFoundError("Missing .env-db-server file")
-with open(env_db_server, "r") as f:
-    for line in f.read().splitlines():
-        if line.startswith("DATASETS_SERVER_API_KEY"):
-            API_KEY = line.split("=")[-1].replace('"', "")
-        if line.startswith("DATASETS_SERVER_URL"):
-            POSTGREST_URL = line.split("=")[-1]
+POSTGREST_URL = os.environ.get("DATASETS_SERVER_URL", "")
+API_KEY = os.environ.get("DATASETS_SERVER_API_KEY", "").replace('"', "")
 POSTGREST_ENDPOINT = "rpc/enermaps_query_table"
 HEADERS = {"Authorization": "Bearer {}".format(API_KEY)}
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,7 +108,8 @@ services:
     volumes:
       - wms_cache:/wms_cache:ro
     env_file:
-      .env
+      - .env
+      - .env-db-server
 
 volumes:
   wms_cache:


### PR DESCRIPTION
This is now possible since an access to the real database server isn't needed anymore during tests