### PR TITLE
Fix build on Apple M1 (arm)

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,14 +1,18 @@
 FROM ubuntu:20.04
 
-ENV DEBIAN_FRONTEND="nointeractive" TZ="Europe/Zurich"
-RUN chmod 1777 /tmp && \
-    apt-get update && apt-get install --yes \
-    python3-mapnik \
-    python3-pip \
-    python3-gunicorn \
-    gunicorn \
-    libpq-dev \
-    python3-gdal && \
+# set timezone
+ENV TZ=Europe/Zurich
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+RUN apt-get update && \
+    apt-get install --yes \
+        python3-mapnik \
+        python3-pip \
+        python3-gunicorn \
+        gunicorn \
+        libpq-dev \
+        python3-gdal \
+        && \
     rm -rf /var/cache/apt/archives/
 
 WORKDIR /api

--- a/cm/cm_heat_demand/Dockerfile
+++ b/cm/cm_heat_demand/Dockerfile
@@ -1,10 +1,20 @@
 FROM ubuntu:20.04
 
-ENV DEBIAN_FRONTEND="nointeractive" TZ="Europe/Zurich"
-RUN chmod 1777 /tmp && \
-    apt-get update && apt-get install --yes \
+# set timezone
+ENV TZ=Europe/Zurich
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+RUN apt-get update && \
+    apt-get --yes install \
+        python3 \
+        python3-pip \
+        libgdal-dev \
+        && \
+    rm -rf /var/cache/apt/archives/
+    
+RUN \
+    apt-get install --yes \
     gdal-bin \
-    python3-pip \
     python3-gdal && \
     rm -rf /var/cache/apt/archives/
 

--- a/cm/cm_heat_demand/Dockerfile
+++ b/cm/cm_heat_demand/Dockerfile
@@ -5,17 +5,13 @@ ENV TZ=Europe/Zurich
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 RUN apt-get update && \
-    apt-get --yes install \
+    apt-get install --yes \
         python3 \
         python3-pip \
         libgdal-dev \
+        gdal-bin \
+        python3-gdal \
         && \
-    rm -rf /var/cache/apt/archives/
-    
-RUN \
-    apt-get install --yes \
-    gdal-bin \
-    python3-gdal && \
     rm -rf /var/cache/apt/archives/
 
 WORKDIR cm-heat-demand

--- a/cm/example_empty/Dockerfile
+++ b/cm/example_empty/Dockerfile
@@ -1,7 +1,17 @@
 FROM ubuntu:20.04
+
+# set timezone
+ENV TZ=Europe/Zurich
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
 RUN apt-get update && \
-    apt-get --yes install python3 python3-pip &&\
+    apt-get --yes install \
+        python3 \
+        python3-pip \
+        libgdal-dev \
+        && \
     rm -rf /var/cache/apt/archives/
+
 # choose the same name as the Docker service (by convention)
 WORKDIR cm-geofile
 # replace [example_empty] by your CM folder name

--- a/cm/example_multiply/Dockerfile
+++ b/cm/example_multiply/Dockerfile
@@ -1,7 +1,17 @@
 FROM ubuntu:20.04
+
+# set timezone
+ENV TZ=Europe/Zurich
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
 RUN apt-get update && \
-    apt-get --yes install python3 python3-pip &&\
+    apt-get --yes install \
+        python3 \
+        python3-pip \
+        libgdal-dev \
+        && \
     rm -rf /var/cache/apt/archives/
+
 WORKDIR cm-multiply
 COPY example_multiply/requirements.txt requirements.txt
 RUN pip3 install -r requirements.txt

--- a/cm/heatlearn/Dockerfile
+++ b/cm/heatlearn/Dockerfile
@@ -9,13 +9,9 @@ RUN apt-get update && \
         python3 \
         python3-pip \
         libgdal-dev \
+        libpq-dev \
+        gdal-bin \
         && \
-    rm -rf /var/cache/apt/archives/
-
-RUN chmod 1777 /tmp && \
-    apt-get update && \
-    apt-get --yes install libpq-dev &&\
-    apt-get --yes install gdal-bin &&\
     rm -rf /var/cache/apt/archives/
 
 ENV CPLUS_INCLUDE_PATH=/usr/include/gdal

--- a/cm/heatlearn/Dockerfile
+++ b/cm/heatlearn/Dockerfile
@@ -1,14 +1,21 @@
 FROM ubuntu:20.04
-# SET TZ for GDAL
+
+# set timezone
 ENV TZ=Europe/Zurich
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
+RUN apt-get update && \
+    apt-get --yes install \
+        python3 \
+        python3-pip \
+        libgdal-dev \
+        && \
+    rm -rf /var/cache/apt/archives/
+
 RUN chmod 1777 /tmp && \
     apt-get update && \
-    apt-get --yes install python3 python3-pip &&\
     apt-get --yes install libpq-dev &&\
     apt-get --yes install gdal-bin &&\
-    apt-get --yes install libgdal-dev &&\
     rm -rf /var/cache/apt/archives/
 
 ENV CPLUS_INCLUDE_PATH=/usr/include/gdal


### PR DESCRIPTION
To be able to build on Apple M1, we need to install libgdal-dev package before.
Without it, the pip installation of gdal, (required by rasterstats), will fail.