### PR TITLE
Fix usage rights for legend_editor API user

### DIFF
--- a/db/init/postgrest.sql
+++ b/db/init/postgrest.sql
@@ -384,6 +384,7 @@ CREATE OR REPLACE FUNCTION enermaps_set_legend(parameters text, legend text)
     $$
     LANGUAGE plpgsql;
 -- Set rights
+GRANT USAGE ON SCHEMA public TO legend_editor;
 GRANT EXECUTE ON FUNCTION enermaps_set_legend(parameters text, legend text) to legend_editor;
 GRANT SELECT, UPDATE ON public.data TO legend_editor;
 GRANT SELECT, INSERT ON public.visualization TO legend_editor;


### PR DESCRIPTION
As seen with @ManuelDalcaEurac, this solves the 403 error when uploading legends via the API. Already run manually in the db.