### PR TITLE
fix(doc): math formula rendering

### DIFF
--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -1,2 +1,3 @@
 .env
+.env.local
 .git/

--- a/doc/docker-compose.dev.yml
+++ b/doc/docker-compose.dev.yml
@@ -1,0 +1,9 @@
+version: "3.8"
+services:
+  wiki:
+    image: enermaps/doc
+    container_name: enermaps-doc
+    env_file: .env.local
+    build: .
+    ports:
+      - "4567:80"

--- a/doc/src/gollum/config.rb
+++ b/doc/src/gollum/config.rb
@@ -10,7 +10,6 @@ wiki_options = {
   :allow_editing => true,
   :css => true,
   :js => true,
-  :mathjax => true,
   :h1_title => true,
 }
 Precious::App.set(:wiki_options, wiki_options)

--- a/doc/src/gollum/templates/layout.mustache
+++ b/doc/src/gollum/templates/layout.mustache
@@ -39,22 +39,21 @@
   {{#has_editor}}
   {{#sprockets_javascript_tag}}editor{{/sprockets_javascript_tag}}
   {{/has_editor}}
-  {{#mathjax}}
   <script type="text/javascript">
+    // https://docs.mathjax.org/en/v2.7-latest/options/preprocessors/tex2jax.html
     window.MathJax = {
       tex2jax: {
         inlineMath:  [ ['$','$'], ['\\(','\\)'] ],
         displayMath: [ ['$$','$$'], ['\\[','\\]'] ],
-        processEscapes: true
+        processEscapes: true,
+        processEnvironments: true,
+        preview: ["[math]"],
       },
       TeX: { extensions: ["autoload-all.js"] }
     };
   </script>
-  {{#mathjax_config}}
   <script type="text/javascript" src="{{mathjax_config_path}}"></script>
-  {{/mathjax_config}}
   <script defer src="{{mathjax_js}}"></script>
-  {{/mathjax}}
   {{#js}}<script type="text/javascript" src="{{custom_js}}"></script>{{/js}}
 
   <title>{{title}}</title>


### PR DESCRIPTION
### Goals

- Make it possible to render math formulas in wiki posts

### Notes

- `MathJax` 2.7 is used in the background for math rendering, and there are some cases when it has trouble rendering formulas written in `LaTex`. In those cases, it is necessary to convert from `LaTex` to `MML`  via a tool such as https://temml.org/
- The `MML` output can be pasted directly into the wiki post body, and it should be rendered properly, as the screenshots below also illustrate it

<img width="947" alt="Screenshot 2022-05-19 at 12 10 03" src="https://user-images.githubusercontent.com/40776291/169271758-5dc2612b-3405-4ca5-b3b8-7b603332b790.png">

<img width="947" alt="Screenshot 2022-05-19 at 12 10 14" src="https://user-images.githubusercontent.com/40776291/169271752-86adc3f2-2284-40a3-b49a-7e2ec3fae713.png">

<img width="947" alt="Screenshot 2022-05-19 at 12 10 17" src="https://user-images.githubusercontent.com/40776291/169271744-784b00e2-4c38-4f00-a528-9a17c826dd7f.png">

