### PR TITLE
Fix the build

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,16 @@ The EnerMaps project has received funding from the European Union’s Horizon 20
 EnerMaps is a rewrite of the Hotmaps Horizon 2020 project.
 
 # Development
+
 First you need to have docker installed on your machine. 
 Please sign into Docker, otherwise the docker compose will not work.
 Clone this repository.
+
+**Notes for the Mac M1 & M2 users:** Some of the libraries used by the project aren't available yet on your platform, so you'll need to:
+
+  - Set the following environment variable before trying to build the images: ```export DOCKER_DEFAULT_PLATFORM=linux/amd64```
+  - Comment the ```cm-heatlearn``` container in the file ```docker-compose.yml```
+
 
 Then run
 

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -13,3 +13,4 @@ seaborn==0.11.1
 gdal==3.0.4
 numpy==1.22.1
 click==7.1.1
+Werkzeug==2.1.2

--- a/cm/base/requirements.txt
+++ b/cm/base/requirements.txt
@@ -13,3 +13,8 @@ requests==2.26.0
 pandas==1.4.1
 geopandas==0.10.2
 pyproj==3.3.0
+click==8.1.3
+rasterio==1.3.1
+numpy==1.22.2
+scipy==1.6.2
+urllib3==1.26.5

--- a/cm/cm_buildingload/Dockerfile
+++ b/cm/cm_buildingload/Dockerfile
@@ -1,12 +1,27 @@
 FROM ubuntu:20.04
+
+# set timezone
+ENV TZ=Europe/Zurich
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+# Install Python
 RUN apt-get update && \
-    apt-get --yes install python3 python3-pip &&\
+    apt-get --yes install \
+        python3 \
+        python3-pip \
+        && \
     rm -rf /var/cache/apt/archives/
-COPY cm/cm_buildingload/requirements.txt requirements.txt
+
+# Install the base library for CMs
+COPY base /tmp/base
+RUN cd /tmp/base && \
+    pip3 install . && \
+    python3 test.py
+
+# Install this CM specific files
+WORKDIR cm-buildingload
+COPY cm_buildingload .
 RUN pip3 install -r requirements.txt
-COPY cm/base /tmp/base
-RUN cd /tmp/base && pip3 install . && python3 test.py
-COPY cm/cm_buildingload .
 RUN mkdir -p tmp
 RUN python3 test.py
 CMD ["python3", "worker.py"]

--- a/cm/cm_buildingload/requirements.txt
+++ b/cm/cm_buildingload/requirements.txt
@@ -6,10 +6,10 @@ redis==3.5.3
 requests
 shapely~=1.7.1
 rasterio~=1.2.8
-rasterstats~=0.15.0
+rasterstats==0.16.0
 pyproj~=3.2.1
 pandas~=1.3.3
-numpy==1.21.0
+numpy==1.22.2
 xarray==0.19.0
 pvlib==0.7.2
 pyshp==2.1.3

--- a/cm/cm_buildingload/requirements.txt
+++ b/cm/cm_buildingload/requirements.txt
@@ -4,7 +4,7 @@ jsonschema==3.2.0
 celery==5.2.2
 redis==3.5.3
 requests
-shapely~=1.7.1
+shapely==1.8.0
 rasterio~=1.2.8
 rasterstats==0.16.0
 pyproj~=3.2.1

--- a/cm/cm_buildingload/requirements.txt
+++ b/cm/cm_buildingload/requirements.txt
@@ -1,18 +1,8 @@
-marshmallow==3.9.1
-marshmallow-union==0.1.15.post1
-jsonschema==3.2.0
-celery==5.2.2
-redis==3.5.3
-requests
-shapely==1.8.0
-rasterio~=1.2.8
-rasterstats==0.16.0
-pyproj~=3.2.1
-pandas~=1.3.3
-numpy==1.22.2
+# The dependencies in the file '../base/requirements.txt' are installed before those,
+# avoid repeating or overriding them in this file
+
 xarray==0.19.0
 pvlib==0.7.2
 pyshp==2.1.3
 openpyxl==3.0.5
-scipy==1.7.1
 python-dateutil==2.8.2

--- a/cm/cm_dhexppot/Dockerfile
+++ b/cm/cm_dhexppot/Dockerfile
@@ -1,24 +1,35 @@
 FROM ubuntu:20.04
 
-# SET TZ for GDAL
+# set timezone
 ENV TZ=Europe/Zurich
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
-RUN chmod 1777 /tmp && \
-    apt-get update && \
-    apt-get --yes install python3 python3-pip &&\
-    apt-get --yes install libpq-dev &&\
-    apt-get --yes install gdal-bin &&\
-    apt-get --yes install libgdal-dev &&\
+# Install Python
+RUN apt-get update && \
+    apt-get --yes install \
+        python3 \
+        python3-pip \
+        && \
     rm -rf /var/cache/apt/archives/
 
-WORKDIR cm-dhexppot
-
-RUN mkdir -p tmp
-COPY cm_dhexppot/requirements.txt requirements.txt
-RUN pip3 install -r requirements.txt
+# Install the base library for CMs
 COPY base /tmp/base
-RUN cd /tmp/base && pip3 install . && python3 test.py
+RUN cd /tmp/base && \
+    pip3 install . && \
+    python3 test.py
+
+# Install additional dependencies (note: we do it after the above steps to take advantage of the cache during builds)
+RUN apt-get install --yes \
+        libgdal-dev \
+        gdal-bin \
+        libpq-dev \
+        && \
+    rm -rf /var/cache/apt/archives/
+
+# Install this CM specific files
+WORKDIR cm-dhexppot
 COPY cm_dhexppot .
+RUN pip3 install -r requirements.txt
+RUN mkdir -p tmp
 RUN python3 test.py
 CMD ["python3", "worker.py"]

--- a/cm/cm_dhexppot/requirements.txt
+++ b/cm/cm_dhexppot/requirements.txt
@@ -1,11 +1,5 @@
-shapely==1.8.0
-rasterio==1.1.8
-pyproj==3.0.0.post1
-geopandas
-urllib3==1.26.5
-jenkspy==0.2.0
-numpy==1.22.2
-scipy==1.6.3
-rasterstats==0.16.0
+# The dependencies in the file '../base/requirements.txt' are installed before those,
+# avoid repeating or overriding them in this file
+
 jenkspy==0.2.0
 matplotlib==3.4.2

--- a/cm/cm_dhexppot/requirements.txt
+++ b/cm/cm_dhexppot/requirements.txt
@@ -4,8 +4,8 @@ pyproj==3.0.0.post1
 geopandas
 urllib3==1.26.5
 jenkspy==0.2.0
-numpy==1.21.0
+numpy==1.22.2
 scipy==1.6.3
-rasterstats==0.14.0
+rasterstats==0.16.0
 jenkspy==0.2.0
 matplotlib==3.4.2

--- a/cm/cm_dhexppot/requirements.txt
+++ b/cm/cm_dhexppot/requirements.txt
@@ -1,4 +1,4 @@
-shapely==1.7.1
+shapely==1.8.0
 rasterio==1.1.8
 pyproj==3.0.0.post1
 geopandas

--- a/cm/cm_heat_demand/Dockerfile
+++ b/cm/cm_heat_demand/Dockerfile
@@ -4,27 +4,31 @@ FROM ubuntu:20.04
 ENV TZ=Europe/Zurich
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
-WORKDIR cm-heat-demand
-
-COPY cm_heat_demand/requirements.txt requirements.txt
-
-# Note: if we install python3-gdal before the requirements, we are stuck with an old
-# numpy version
+# Install Python
 RUN apt-get update && \
-    apt-get install --yes \
+    apt-get --yes install \
         python3 \
         python3-pip \
         && \
-    pip3 install -r requirements.txt && \
-    apt-get install --yes \
+    rm -rf /var/cache/apt/archives/
+
+# Install the base library for CMs
+COPY base /tmp/base
+RUN cd /tmp/base && \
+    pip3 install . && \
+    python3 test.py
+
+# Install additional dependencies (note: we do it after the above steps to take advantage of the cache during builds)
+RUN apt-get install --yes \
         libgdal-dev \
         gdal-bin \
         python3-gdal \
         && \
     rm -rf /var/cache/apt/archives/
 
-COPY base /tmp/base
-RUN cd /tmp/base && pip3 install . && python3 test.py
+# Install this CM specific files
+WORKDIR cm-heat-demand
 COPY cm_heat_demand .
+RUN pip3 install -r requirements.txt
 RUN python3 test.py
 CMD ["python3", "worker.py"]

--- a/cm/cm_heat_demand/Dockerfile
+++ b/cm/cm_heat_demand/Dockerfile
@@ -4,20 +4,25 @@ FROM ubuntu:20.04
 ENV TZ=Europe/Zurich
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
+WORKDIR cm-heat-demand
+
+COPY cm_heat_demand/requirements.txt requirements.txt
+
+# Note: if we install python3-gdal before the requirements, we are stuck with an old
+# numpy version
 RUN apt-get update && \
     apt-get install --yes \
         python3 \
         python3-pip \
+        && \
+    pip3 install -r requirements.txt && \
+    apt-get install --yes \
         libgdal-dev \
         gdal-bin \
         python3-gdal \
         && \
     rm -rf /var/cache/apt/archives/
 
-WORKDIR cm-heat-demand
-
-COPY cm_heat_demand/requirements.txt requirements.txt
-RUN pip3 install -r requirements.txt
 COPY base /tmp/base
 RUN cd /tmp/base && pip3 install . && python3 test.py
 COPY cm_heat_demand .

--- a/cm/cm_heat_demand/requirements.txt
+++ b/cm/cm_heat_demand/requirements.txt
@@ -1,11 +1,6 @@
-geojson==2.5.0
-numpy==1.22.2
-scipy==1.6.2
-rasterio==1.1.8
+# The dependencies in the file '../base/requirements.txt' are installed before those,
+# avoid repeating or overriding them in this file
+
 varname==0.6.3
-requests==2.25.1
-shapely==1.8.0
-pyproj==3.0.0.post1
-rasterstats==0.16.0
 jenkspy==0.2.0
 matplotlib==3.4.2

--- a/cm/cm_heat_demand/requirements.txt
+++ b/cm/cm_heat_demand/requirements.txt
@@ -1,11 +1,11 @@
 geojson==2.5.0
-numpy==1.21.0
+numpy==1.22.2
 scipy==1.6.2
 rasterio==1.1.8
 varname==0.6.3
 requests==2.25.1
 shapely==1.8.0
 pyproj==3.0.0.post1
-rasterstats==0.15.0
+rasterstats==0.16.0
 jenkspy==0.2.0
 matplotlib==3.4.2

--- a/cm/cm_raster_statistics/Dockerfile
+++ b/cm/cm_raster_statistics/Dockerfile
@@ -4,19 +4,23 @@ FROM ubuntu:20.04
 ENV TZ=Europe/Zurich
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
+# Install Python
 RUN apt-get update && \
     apt-get --yes install \
         python3 \
         python3-pip \
-        libgdal-dev \
         && \
     rm -rf /var/cache/apt/archives/
 
-WORKDIR cm-raster-statistics
-COPY cm_raster_statistics/requirements.txt requirements.txt
-RUN pip3 install -r requirements.txt
+# Install the base library for CMs
 COPY base /tmp/base
-RUN cd /tmp/base && pip3 install . && python3 test.py
+RUN cd /tmp/base && \
+    pip3 install . && \
+    python3 test.py
+
+# Install this CM specific files
+WORKDIR cm-raster-statistics
 COPY cm_raster_statistics .
+RUN pip3 install -r requirements.txt
 RUN python3 test.py
 CMD ["python3", "worker.py"]

--- a/cm/cm_raster_statistics/requirements.txt
+++ b/cm/cm_raster_statistics/requirements.txt
@@ -1,4 +1,3 @@
-shapely==1.8.0
-rasterstats==0.16.0
-rasterio==1.1.8
-pyproj==3.0.0.post1
+# The dependencies in the file '../base/requirements.txt' are installed before those,
+# avoid repeating or overriding them in this file
+

--- a/cm/cm_raster_statistics/requirements.txt
+++ b/cm/cm_raster_statistics/requirements.txt
@@ -1,4 +1,4 @@
 shapely==1.8.0
-rasterstats==0.15.0
+rasterstats==0.16.0
 rasterio==1.1.8
 pyproj==3.0.0.post1

--- a/cm/example_empty/Dockerfile
+++ b/cm/example_empty/Dockerfile
@@ -4,22 +4,23 @@ FROM ubuntu:20.04
 ENV TZ=Europe/Zurich
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
+# Install Python
 RUN apt-get update && \
     apt-get --yes install \
         python3 \
         python3-pip \
-        libgdal-dev \
         && \
     rm -rf /var/cache/apt/archives/
 
-# choose the same name as the Docker service (by convention)
-WORKDIR example-empty
-# replace [example_empty] by your CM folder name
-COPY example_empty/requirements.txt requirements.txt
-RUN pip3 install -r requirements.txt
+# Install the base library for CMs
 COPY base /tmp/base
-RUN cd /tmp/base && pip3 install . && python3 test.py
-# replace [example_empty] by your CM folder name
+RUN cd /tmp/base && \
+    pip3 install . && \
+    python3 test.py
+
+# Install this CM specific files
+WORKDIR cm-example
 COPY example_empty .
+RUN pip3 install -r requirements.txt
 RUN python3 test.py
 CMD ["python3", "worker.py"]

--- a/cm/example_empty/requirements.txt
+++ b/cm/example_empty/requirements.txt
@@ -1,0 +1,3 @@
+# The dependencies in the file '../base/requirements.txt' are installed before those,
+# avoid repeating or overriding them in this file
+

--- a/cm/example_multiply/Dockerfile
+++ b/cm/example_multiply/Dockerfile
@@ -4,19 +4,23 @@ FROM ubuntu:20.04
 ENV TZ=Europe/Zurich
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
+# Install Python
 RUN apt-get update && \
     apt-get --yes install \
         python3 \
         python3-pip \
-        libgdal-dev \
         && \
     rm -rf /var/cache/apt/archives/
 
-WORKDIR cm-multiply
-COPY example_multiply/requirements.txt requirements.txt
-RUN pip3 install -r requirements.txt
+# Install the base library for CMs
 COPY base /tmp/base
-RUN cd /tmp/base && pip3 install . && python3 test.py
+RUN cd /tmp/base && \
+    pip3 install . && \
+    python3 test.py
+
+# Install this CM specific files
+WORKDIR cm-multiply
 COPY example_multiply .
+RUN pip3 install -r requirements.txt
 RUN python3 test.py
 CMD ["python3", "worker.py"]

--- a/cm/example_multiply/requirements.txt
+++ b/cm/example_multiply/requirements.txt
@@ -1,4 +1,3 @@
-shapely==1.8.0
-rasterstats==0.16.0
-rasterio==1.1.8
-pyproj==3.0.0.post1
+# The dependencies in the file '../base/requirements.txt' are installed before those,
+# avoid repeating or overriding them in this file
+

--- a/cm/example_multiply/requirements.txt
+++ b/cm/example_multiply/requirements.txt
@@ -1,4 +1,4 @@
 shapely==1.8.0
-rasterstats==0.15.0
+rasterstats==0.16.0
 rasterio==1.1.8
 pyproj==3.0.0.post1

--- a/cm/hdd_cdd/Dockerfile
+++ b/cm/hdd_cdd/Dockerfile
@@ -1,21 +1,33 @@
 FROM ubuntu:20.04
 
-## ------------
-## Set timezone
-## ------------
+## -------------------------
+## Setup common to all CMs
+## -------------------------
+
+# set timezone
 ENV TZ=Europe/Zurich
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+# Install Python
+RUN apt-get update && \
+    apt-get --yes install \
+        python3 \
+        python3-pip \
+        && \
+    rm -rf /var/cache/apt/archives/
+
+# Install the base library for CMs
+COPY base /tmp/base
+RUN cd /tmp/base && \
+    pip3 install . && \
+    python3 test.py
 
 ## -------------------------
 ## Install required software
 ## -------------------------
-RUN apt-get update \
-    && apt-get --yes install \
-    python3 \
-    python3-pip \
-    libgdal-dev \
+RUN apt-get --yes install \
+        libgdal-dev \
     && rm -rf /var/cache/apt/archives/
-
 
 ## ----------------------
 ## Set main env variables
@@ -35,18 +47,6 @@ RUN echo "/cm_input: ${INPUT_DATA_DIR}" \
 WORKDIR hdd_cdd
 COPY hdd_cdd .
 RUN pip3 install -r requirements.txt
-
-COPY base /tmp/base
-## the lines bellow where use to check that the we were using the latest version
-## sometime the docker cache might create some issues, if it is the case use:
-## docker-compose --file docker-compose-cm-test.yml build --no-cache cm-hdd_cdd
-# RUN echo "-----" && head -n 50 /tmp/base/BaseCM/cm_hddcdd.py && echo "-----"
-# RUN echo "-----" && head -n 50 /tmp/base/BaseCM/test_hddcdd.py && echo "-----"
-RUN echo "-----\nInstalling BaseCM" \
-    && cd /tmp/base && python3 setup.py install \
-    && python3 test.py \
-    && echo "-----\n"
-
 
 ## ---------------------------------
 ## Download required data and layers

--- a/cm/hdd_cdd/requirements.txt
+++ b/cm/hdd_cdd/requirements.txt
@@ -1,4 +1,4 @@
-shapely~=1.7.1
+shapely==1.8.0
 rasterio~=1.2.8
 rasterstats==0.16.0
 pyproj~=3.2.1

--- a/cm/hdd_cdd/requirements.txt
+++ b/cm/hdd_cdd/requirements.txt
@@ -1,7 +1,3 @@
-shapely==1.8.0
-rasterio~=1.2.8
-rasterstats==0.16.0
-pyproj~=3.2.1
-pandas~=1.3.3
-geopandas==0.10.2
-numpy==1.22.2
+# The dependencies in the file '../base/requirements.txt' are installed before those,
+# avoid repeating or overriding them in this file
+

--- a/cm/hdd_cdd/requirements.txt
+++ b/cm/hdd_cdd/requirements.txt
@@ -1,6 +1,7 @@
 shapely~=1.7.1
 rasterio~=1.2.8
-rasterstats~=0.15.0
+rasterstats==0.16.0
 pyproj~=3.2.1
 pandas~=1.3.3
 geopandas==0.10.2
+numpy==1.22.2

--- a/cm/heatlearn/Dockerfile
+++ b/cm/heatlearn/Dockerfile
@@ -4,24 +4,36 @@ FROM ubuntu:20.04
 ENV TZ=Europe/Zurich
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
+# Install Python
 RUN apt-get update && \
     apt-get --yes install \
         python3 \
         python3-pip \
-        libgdal-dev \
-        libpq-dev \
-        gdal-bin \
         && \
     rm -rf /var/cache/apt/archives/
+
+# Install the base library for CMs
+COPY base /tmp/base
+RUN cd /tmp/base && \
+    pip3 install . && \
+    python3 test.py
+
+# Install additional dependencies (note: we do it after the above steps to take advantage of the cache during builds)
+RUN apt-get install --yes \
+        libgdal-dev \
+        gdal-bin \
+        libpq-dev \
+        && \
+    rm -rf /var/cache/apt/archives/
+
+# Install this CM specific files
+WORKDIR cm-heatlearn
 
 ENV CPLUS_INCLUDE_PATH=/usr/include/gdal
 ENV C_INCLUDE_PATH=/usr/include/gdal
 
-COPY cm/heatlearn/requirements.txt requirements.txt
+COPY heatlearn .
 RUN pip3 install -r requirements.txt
-COPY cm/base /tmp/base
-RUN cd /tmp/base && pip3 install . && python3 test.py
-COPY cm/heatlearn .
 RUN mkdir -p tmp
 RUN python3 test.py
 CMD ["python3", "worker.py"]

--- a/cm/heatlearn/requirements.txt
+++ b/cm/heatlearn/requirements.txt
@@ -1,12 +1,7 @@
-shapely==1.8.0
-rasterstats==0.16.0
-rasterio==1.1.8
-pyproj==3.0.0.post1
-geopandas==0.8.2
+# The dependencies in the file '../base/requirements.txt' are installed before those,
+# avoid repeating or overriding them in this file
+
 matplotlib==3.4.2
 tensorflow==2.7.2
-urllib3==1.26.5
 jenkspy==0.2.0
-numpy==1.22.2
-scipy==1.6.3
 protobuf==3.20.1

--- a/cm/heatlearn/requirements.txt
+++ b/cm/heatlearn/requirements.txt
@@ -1,5 +1,5 @@
 shapely==1.8.0
-rasterstats==0.15.0
+rasterstats==0.16.0
 rasterio==1.1.8
 pyproj==3.0.0.post1
 geopandas==0.8.2
@@ -7,5 +7,6 @@ matplotlib==3.4.2
 tensorflow==2.7.2
 urllib3==1.26.5
 jenkspy==0.2.0
-numpy==1.21.0
+numpy==1.22.2
 scipy==1.6.3
+protobuf==3.20.1

--- a/cm/refurbish/Dockerfile
+++ b/cm/refurbish/Dockerfile
@@ -1,22 +1,35 @@
 FROM ubuntu:20.04
 
-## ------------
-## Set timezone
-## ------------
+## -------------------------
+## Setup common to all CMs
+## -------------------------
+
+# set timezone
 ENV TZ=Europe/Zurich
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+# Install Python
+RUN apt-get update && \
+    apt-get --yes install \
+        python3 \
+        python3-pip \
+        && \
+    rm -rf /var/cache/apt/archives/
+
+# Install the base library for CMs
+COPY base /tmp/base
+RUN cd /tmp/base && \
+    pip3 install . && \
+    python3 test.py
 
 
 ## -------------------------
 ## Install required software
 ## -------------------------
-RUN apt-get update \
-    && apt-get --yes install \
-    git \
-    python3 \
-    python3-pip \
-    gdal-bin \
-    libgdal-dev \
+RUN apt-get --yes install \
+        git \
+        gdal-bin \
+        libgdal-dev \
     && rm -rf /var/cache/apt/archives/
 
 
@@ -43,18 +56,6 @@ RUN echo "/cm_input: ${INPUT_DATA_DIR}" \
 WORKDIR refurbish
 COPY refurbish .
 RUN pip3 install -r requirements.txt
-
-COPY base /tmp/base
-## the lines bellow where use to check that the we were using the latest version
-## sometime the docker cache might create some issues, if it is the case use:
-## docker-compose --file docker-compose-cm-test.yml build --no-cache cm-hdd_cdd
-# RUN echo "-----" && head -n 50 /tmp/base/BaseCM/cm_hddcdd.py && echo "-----"
-# RUN echo "-----" && head -n 50 /tmp/base/BaseCM/test_hddcdd.py && echo "-----"
-RUN echo "-----\nInstalling BaseCM" \
-    && cd /tmp/base && pip3 install . \
-    && python3 test.py \
-    && echo "-----\n"
-
 
 ## ---------------------------------
 ## Download required data and layers

--- a/cm/refurbish/requirements.txt
+++ b/cm/refurbish/requirements.txt
@@ -1,8 +1,5 @@
-numpy==1.22.2
-shapely==1.8.0
-rasterio~=1.2.10
-pyproj~=3.2.1
-geopandas==0.10.2
-pandas==1.3.4
+# The dependencies in the file '../base/requirements.txt' are installed before those,
+# avoid repeating or overriding them in this file
+
 openpyxl==3.0.9
 git+https://github.com/HotMaps/resutils.git

--- a/cm/refurbish/requirements.txt
+++ b/cm/refurbish/requirements.txt
@@ -1,5 +1,5 @@
 numpy==1.22.2
-shapely~=1.7.1
+shapely==1.8.0
 rasterio~=1.2.10
 pyproj~=3.2.1
 geopandas==0.10.2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,8 +131,8 @@ services:
 
   cm-heatlearn:
     build:
-      context: ./
-      dockerfile: ./cm/heatlearn/Dockerfile
+      context: ./cm
+      dockerfile: heatlearn/Dockerfile
     environment:
       WMS_CACHE_DIR: /wms_cache
     depends_on:
@@ -147,7 +147,7 @@ services:
   cm-dhexppot:
     build:
       context: ./cm
-      dockerfile: ./cm_dhexppot/Dockerfile
+      dockerfile: cm_dhexppot/Dockerfile
     environment:
       WMS_CACHE_DIR: /wms_cache
     depends_on:
@@ -161,8 +161,8 @@ services:
 
   cm-buildingload:
     build:
-      context: ./
-      dockerfile: ./cm/cm_buildingload/Dockerfile
+      context: ./cm
+      dockerfile: cm_buildingload/Dockerfile
     environment:
       WMS_CACHE_DIR: /wms_cache
     depends_on:


### PR DESCRIPTION
- Fix the version of several unlisted dependencies
- Ensure that the CMs don't override the dependencies common to all CMs (which result in uninstallations and wasted bandwidth and time)
- Rewrite the Dockerfiles of the CMs to take advantage of the cache of Docker to speed-up the build time (ie. the first 19 lines of each Dockerfile are exactly the same for all the CMs, and produce an image with python, pip, and the base library for the CMs installed)
